### PR TITLE
set project name to reflect name of the tutorial

### DIFF
--- a/examples/hoomd-lj/src/init.py
+++ b/examples/hoomd-lj/src/init.py
@@ -12,7 +12,7 @@ import numpy as np
 
 
 def main(args, random_seed):
-    project = signac.init_project('Ideal-Gas-Example-Project')
+    project = signac.init_project('Lennard-Jones-Fluid-Example-Project')
     for replication_index in range(args.num_replicas):
         for p in np.linspace(0.5, 5.0, 10):
             statepoint = dict(

--- a/examples/hoomd-lj/src/project.py
+++ b/examples/hoomd-lj/src/project.py
@@ -33,7 +33,7 @@ def initialize(job):
 @Project.operation
 @Project.post(lambda job: 'volume_estimate' in job.document)
 def estimate(job):
-    "Find volume predicted by ideal gas law"
+    "Find volume predicted by ideal gas law as an estimate of the LJ fluid."
     # Since we are not simulating an ideal gas our simulation volume
     # may be different than the volume calculated here
     V = job.sp.N * job.sp.kT / job.sp.p

--- a/examples/hoomd-lj/src/project.py
+++ b/examples/hoomd-lj/src/project.py
@@ -33,8 +33,9 @@ def initialize(job):
 @Project.operation
 @Project.post(lambda job: 'volume_estimate' in job.document)
 def estimate(job):
-    "Ideal-gas estimate operation."
-    # Calculate volume using ideal gas law
+    "Find volume predicted by ideal gas law"
+    # Since we are not simulating an ideal gas our simulation volume
+    # may be different than the volume calculated here
     V = job.sp.N * job.sp.kT / job.sp.p
     job.document.volume_estimate = V
 


### PR DESCRIPTION
This fixes issue #51 

Really the only issue with the tutorial was calling this an ideal gas project when really it is comparing an LJ fluid to an ideal gas. 