### PR TITLE
Add LICENSE.

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -10,15 +10,15 @@ assignees: ''
 
 ### Issue Description
 
-A concise description of the proposed improvement or the problem it solves.
-For example: "I would like to ..." or "It would be nice if it was easier to ...".
+A concise description of the proposed improvement or the issue that is addressed.
+Examples:
+ - "This change improves the overall structure of the tutorial."
+ - "This change fixes the links to the Project class API."
 
-### Proposed solution
+### Proposed change (optional)
 
-A description of how you would like a possible solution to look like.
+A description of how a change to address this issue might look like.
 
-*Proposals for an implementation of the idea are welcome, but not necessary.*
+### Additional context (optional)
 
-### Additional context
-
-Any alternative solutions you might have considered or other information that might be helpful.
+Any alternatives you might have considered or other information that might be helpful.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,24 @@
+---
+name: Documentation Improvement
+about: Suggest an improvement to signac-docs
+title: ''
+labels: ''
+assignees: ''
+
+---
+<!-- Please replace the text in the individual sections below. -->
+
+### Issue Description
+
+A concise description of the proposed improvement or the problem it solves.
+For example: "I would like to ..." or "It would be nice if it was easier to ...".
+
+### Proposed solution
+
+A description of how you would like a possible solution to look like.
+
+*Proposals for an implementation of the idea are welcome, but not necessary.*
+
+### Additional context
+
+Any alternative solutions you might have considered or other information that might be helpful.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!-- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!-- Describe your changes in detail -->
+
+## Motivation and Context
+<!-- Why is this change required? What problem does it solve? -->
+<!-- If it fixes an open issue, please link to the issue here. -->
+
+## Checklist:
+<!-- Please select all items that apply either now or after creating the pull request. -->
+<!-- If you are unsure about any of these items, do not hesitate to ask! -->
+- [ ] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md).
+- [ ] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-docs/blob/master/ContributorAgreement.md).
+- [ ] My code follows the [code style guideline](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md#code-style) of this project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# How to Contribute to the Project
+
+## Providing Feedback
+
+Issue reports and feature proposals are very welcome.
+Please use the [GitHub issue page](https://github.com/glotzerlab/signac-docs/issues/) for this.
+
+## Writing Documentation
+
+The API of each package as part of the framework is documented in the form of doc-strings, which are published on https://docs.signac.io/projects/$package, where `$package` is currently one of `core`, `flow`, or `dashboard`.
+A more general introduction in the form of tutorials, guides, and recipes is published as part of the framework documentation: https://docs.signac.io.
+
+Anyone is invited to add to or edit any part of the documentation.
+To fix a spelling mistake or to make a minor edits, just click on the **Edit on GitHub** button in the top-right corner.
+We recommend to clone the signac-docs repository for more substantial edits on your local machine.
+
+## Contributing Code
+
+Code contributions to the signac-docs open-source project are welcomed via pull requests on GitHub.
+Prior any work you should contact the signac developers to ensure that the planned development meshes well with the directions and standards of the project.
+All contributors must agree to the Contributor Agreement ([ContributorAgreement.md](ContributorAgreement.md)) before their pull request can be merged.
+
+### Guideline for Code Contributions
+
+  * Use the [OneFlow](https://www.endoflineblog.com/oneflow-a-git-branching-model-and-workflow) model of development:
+    - Both new features and bug fixes should be developed in branches based on `master`.
+    - Hotfixes (critical bugs that need to be released *fast*) should be developed in a branch based on the latest tagged release.
+  * Write code that is compatible with all supported versions of Python (listed in [setup.py](https://github.com/glotzerlab/signac/blob/master/setup.py)).
+  * Avoid introducing dependencies -- especially those that might be harder to install in high-performance computing environments.
+  * Create [unit tests](https://en.wikipedia.org/wiki/Unit_testing) and [integration tests](https://en.wikipedia.org/wiki/Integration_testing) that cover the common cases and the corner cases of the code.
+  * Preserve backwards-compatibility whenever possible, and make clear if something must change.
+  * Document any portions of the code that might be less clear to others, especially to new developers.
+  * Write API documentation in this package, and put usage information, guides, and concept overviews in the [framework documentation](https://docs.signac.io/) ([source](https://github.com/glotzerlab/signac-docs/)).
+
+Please see the [Support](https://docs.signac.io/projects/signac-core/en/latest/support.html) section as part of the documentation for detailed development guidelines.
+
+### Code style
+
+Code submitted to the signac-docs project must adhere to the [PEP8 style guide](https://www.python.org/dev/peps/pep-0008/) with the exception that lines may have up to 100 characters.
+
+We recommend to use [flake8](http://flake8.pycqa.org/en/latest/) and [autopep8](https://pypi.org/project/autopep8/) to find and fix any code style issues prior to committing and pushing.
+
+## Reviewing Pull Requests
+
+Pull requests represent the standard way of contributing code to the code base.
+Each pull request is assigned to one of the maintainers, who is responsible for triaging it, finding at least two reviewers (one of them can be themselves), and to eventually merge or decline it.
+Pull requests should generally be approved by two reviewers prior to merge.
+
+### Guideline for pull request reviewers
+
+The following items represent a general guideline for points that should be considered during the review process:
+
+* Breaking changes to the API should be avoided whenever possible and require approval by a lead maintainer.
+* Significant performance degradations must be avoided unless the regression is necessary to fix a bug.
+* Updates for non-trivial bug fixes should be accompanied by a unit test that catches the related issue to avoid future regression.
+* The code is easy to follow and sufficiently documented to be understandable even to developers who are not highly familiar with the code.
+* Code duplication should be avoided and existing classes and functions are effectively reused.
+* The pull request is on-topic and does not introduce multiple independent changes (e.g. unrelated style fixes etc.).
+* A potential increase in code complexity introduced with this update is well justified by the benefits of the added feature.
+* The API of a new feature is well-documented in the doc-strings and usage is documented as part of the [framework documentation](https://github.com/glotzerlab/signac-docs).

--- a/ContributorAgreement.md
+++ b/ContributorAgreement.md
@@ -1,0 +1,29 @@
+# signac-docs Contributor Agreement
+
+These terms apply to your contribution to the signac-docs Open Source Project ("Project") owned or managed by the Regents of the University of Michigan ("Michigan"), and set out the intellectual property rights you grant to Michigan in the contributed materials. If this contribution is on behalf of a company, the term "you" will also mean the company you identify below. If you agree to be bound by these terms, fill in the information requested below and provide your signature.
+
+1. The term "contribution" means any source code, object code, patch, tool, sample, graphic, specification, manual, documentation, or any other material posted or submitted by you to a project.
+2. With respect to any worldwide copyrights, or copyright applications and registrations, in your contribution:
+    * you hereby assign to Michigan joint ownership, and to the extent that such assignment is or becomes invalid, ineffective or unenforceable, you hereby grant to Michigan a perpetual, irrevocable, non-exclusive, worldwide, no-charge, royalty-free, unrestricted license to exercise all rights under those copyrights. This includes, at Michigan's option, the right to sublicense these same rights to third parties through multiple levels of sublicensees or other licensing arrangements;
+    * you agree that both Michigan and you can do all things in relation to your contribution as if each of us were the sole owners, and if one of us makes a derivative work of your contribution, the one who makes the derivative work (or has it made) will be the sole owner of that derivative work;
+    * you agree that you will not assert any moral rights in your contribution against us, our licensees or transferees;
+    * you agree that we may register a copyright in your contribution and exercise all ownership rights associated with it; and
+    * you agree that neither of us has any duty to consult with, obtain the consent of, pay or render an accounting to the other for any use or distribution of your contribution.
+3. With respect to any patents you own, or that you can license without payment to any third party, you hereby grant to Michigan a perpetual, irrevocable, non-exclusive, worldwide, no-charge, royalty-free license to:
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer your contribution in whole or in part, alone or in combination with or included in any product, work or materials arising out of the project to which your contribution was submitted; and
+    * at Michigan's option, to sublicense these same rights to third parties through multiple levels of sublicensees or other licensing arrangements.
+4. Except as set out above, you keep all right, title, and interest in your contribution. The rights that you grant to Michigan under these terms are effective on the date you first submitted a contribution to Michigan, even if your submission took place before the date you sign these terms. Any contribution Michigan makes available under any license will also be made available under a suitable Free Software Foundation or Open Source Initiative approved license.
+5. With respect to your contribution, you represent that:
+    * it is an original work and that you can legally grant the rights set out in these terms;
+    * it does not to the best of your knowledge violate any third party's copyrights, trademarks, patents, or other intellectual property rights; and
+you are authorized to sign this contract on behalf of your company (if identified below).
+6. The terms will be governed by the laws of the State of Michigan and applicable U.S. Federal Law. Any choice of law rules will not apply.
+
+**By making contribution, you electronically sign and agree to the terms of the signac-docs Contributor Agreement.**
+
+![by-sa.png](https://licensebuttons.net/l/by-sa/3.0/88x31.png)
+
+Based on the Sun Contributor Agreement - version 1.5.
+This document is licensed under a Creative Commons Attribution-Share Alike 3.0 Unported License
+http://creativecommons.org/licenses/by-sa/3.0/
+

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,29 @@
+BSD 3-Clause License for the software signac-docs.
+
+Copyright (c) 2016, The Regents of the University of Michigan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+3.  Neither the name of the copyright holder nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
This repository was missing a license and contributing agreement. I also added templates for issues and pull requests. These are modified slightly from the files in signac and signac-flow repositories to account for the fact that this is mostly documentation. We also don't track contributors or changelogs in this repository -- I don't think that is needed, so I removed the corresponding sections of those documents.