### PR TITLE
Edited tutorial documentation

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -69,7 +69,7 @@ We can verify that the initialization worked by examining the *implicit* schema 
     {
      'N': 'int([1000], 1)',
      'kT': 'float([1.0], 1)',
-     'p': 'int([1, 2, 3, ..., 9, 10], 10)',
+     'p': 'int([1, 2, 3, ..., 9], 9)',
     }
 
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -69,7 +69,7 @@ We can verify that the initialization worked by examining the *implicit* schema 
     {
      'N': 'int([1000], 1)',
      'kT': 'float([1.0], 1)',
-     'p': 'int([1, 2, 3, ..., 9], 9)',
+     'p': 'int([1, 2, 3, ..., 8, 9], 9)',
     }
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
The documented output from signac schema for the ideal gas tutorial gives the incorrect pressure range 0 to 10. From the init script, the result is 0 to 9 and the change correctly shows that.
## Description
Changed the beginning of the tutorial documentation to correctly reflect the output of signac schema. 

## Motivation and Context
Fixes issue: https://github.com/glotzerlab/signac-docs/issues/72

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-docs/blob/master/ContributorAgreement.md).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md#code-style) of this project.
