### PR TITLE
adding flow more explicitly to quickstart and tutorial

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -6,7 +6,7 @@ Quickstart
 
 .. todo:: Consider replacing this with a screencast!
 
-To get started, first :ref:`install <installation>` **signac** and then setup a new project with:
+To get started, first :ref:`install <installation>` **signac** and  **signac-flow**, then set up a new project with:
 
 .. code-block:: bash
 
@@ -28,7 +28,7 @@ Once a project has been created, the next step is to initialize the *data space*
     ~/my_project $ python init.py
 
 The key is using the Python *project* handle as the interface to initialize jobs (data points) in your data space.
-You can then implement a simple *data space operation* within a ``project.py`` script:
+You can then implement a simple *data space operation* using **signac-flow** within a ``project.py`` script:
 
 .. literalinclude:: ../../examples/quickstart/project.py
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -11,7 +11,7 @@ Tutorial
 
 .. _signac-docs: https://github.com/glotzerlab/signac-docs
 
-This tutorial is designed to step new users through the basics of setting up a **signac** data space, defining and executing a simple workflow, and analyzing the data.
+This tutorial is designed to step new users through the basics of setting up a **signac** data space, defining and executing a simple workflow with **signac-flow**, and analyzing the data.
 For the complete code corresponding to this tutorial, see the :ref:`idg_example` example.
 
 
@@ -210,7 +210,7 @@ Workflows
 =========
 
 
-Implementing a simple workflow
+Implementing a simple workflow with signac-flow
 ------------------------------
 
 In many cases, it is desirable to avoid the repeat execution of data space operations, especially if they are not `idempotent <https://en.wikipedia.org/wiki/Idempotence>`_ or are significantly more expensive than our simple example.

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -210,11 +210,11 @@ Workflows
 =========
 
 
-Implementing a simple workflow with signac-flow
+Implementing a simple workflow
 ------------------------------
 
 In many cases, it is desirable to avoid the repeat execution of data space operations, especially if they are not `idempotent <https://en.wikipedia.org/wiki/Idempotence>`_ or are significantly more expensive than our simple example.
-For this, we will incorporate the ``compute_volume()`` function into a workflow using the :py:class:`~.flow.FlowProject` class.
+For this, we will incoporate the ``compute_volume()`` function into a workflow using the package ``signac-flow`` and its :class:`~.flow.FlowProject` class.
 We slightly modify our ``project.py`` script:
 
 .. code-block:: python


### PR DESCRIPTION
## Description

explicitly stating where signac-flow is introduced when it is used in tutorials

## Motivation and Context
addressing #83 


- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-docs/blob/master/ContributorAgreement.md).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md#code-style) of this project.
