### PR TITLE
Simple sphinx settings to improve navigation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,7 +95,6 @@ html_favicon = "images/favicon.ico"
 # documentation.
 html_theme_options = {
     'collapse_navigation': False, # now show the [+] icon to expand headings in the sidebar. Default=True
-    'navigation_depth': 3, # makes the sidebar less cluttered. Default=4
     'prev_next_buttons_location': 'both' # helps quicken skimming through doc pages. Default='bottom'
 }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -93,8 +93,11 @@ html_favicon = "images/favicon.ico"
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#
-# html_theme_options = {}
+html_theme_options = {
+    'collapse_navigation': False, # shows the [+] icon to expand headings in the sidebar
+    'navigation_depth': 3, # makes the sidebar less cluttered
+    'prev_next_buttons_location': 'both' # helps quicken skimming through doc pages
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,9 +94,9 @@ html_favicon = "images/favicon.ico"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    'collapse_navigation': False, # shows the [+] icon to expand headings in the sidebar
-    'navigation_depth': 3, # makes the sidebar less cluttered
-    'prev_next_buttons_location': 'both' # helps quicken skimming through doc pages
+    'collapse_navigation': False, # now show the [+] icon to expand headings in the sidebar. Default=True
+    'navigation_depth': 3, # makes the sidebar less cluttered. Default=4
+    'prev_next_buttons_location': 'both' # helps quicken skimming through doc pages. Default='bottom'
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
Small fix to improve navigability of the docs while large scale projects like #64 continue.

<!-- Describe your changes in detail -->
## Motivation
I always felt lost in the docs, particularly by not knowing the hierarchy of items in the sidebar.

## Details
With these settings:
- show a plus sign when mousing over headings in the sidebar to avoid having to click to load the page to expand the subtree
- show navigation buttons at top and bottom of page because lots of our pages are long

The options are described [here](https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html).

**Before**
![old](https://user-images.githubusercontent.com/21282461/88354060-aee9c600-cd2d-11ea-8b4d-39c42e2b1110.gif)
**After**
![new](https://user-images.githubusercontent.com/21282461/88354064-b27d4d00-cd2d-11ea-9b52-741927dbb2a5.gif)

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-docs/blob/master/ContributorAgreement.md).
- [ ] My code follows the [code style guideline](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md#code-style) of this project.
