### PR TITLE
Added warning about concurrent access to project-level data

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -188,6 +188,7 @@ intersphinx_mapping = {
     'flow': ('https://docs.signac.io/projects/flow/en/latest/', None),
     'signac_dashboard': ('https://docs.signac.io/projects/dashboard/en/latest/', None),
     'pymongo': ('https://api.mongodb.com/python/current/', None),
+    'h5py': ('https://docs.h5py.org/en/stable/', None),
 }
 
 # -- Options for todo extension ----------------------------------------------

--- a/docs/source/jobs.rst
+++ b/docs/source/jobs.rst
@@ -407,7 +407,23 @@ Please see the :ref:`accessing arrays <accessing-arrays>` section for details on
 
 .. warning::
 
-    It is recommended to use `file locks <https://pypi.org/project/filelock/>`_ when accessing HDF5 files in parallel, *i.e.*, from multiple operations that are independent from each other.
+    Be careful when accessing the job data concurrently from different running operations, as the underlying HDF5 file is locked by default, even when data is only being read from. When trying to read concurrently you may get the following exception:
+
+        .. code-block:: none
+
+            OSError: Unable to open file (unable to lock file, errno = 11, error message = 'Resource temporarily unavailable').
+
+    If data will **only** be read concurrently, the environment variable ``HDF5_USE_FILE_LOCKING`` can safely be set to ``FALSE`` to avoid this behavior.
+    For concurrent writing and reading, try using one of the following approaches:
+
+    * :ref:`Single Writer Multiple Reader features of h5py <h5py:swmr>`
+    * |multiprocessing_sync|_
+    * |posix_ipc_semaphores|_
+
+.. _multiprocessing_sync: https://docs.python.org/3/library/multiprocessing.html#synchronization-between-processes
+.. |multiprocessing_sync| replace:: the synchronization primitives of the ``multiprocessing`` module
+.. _posix_ipc_semaphores: https://semanchuk.com/philip/posix_ipc/#semaphore
+.. |posix_ipc_semaphores| replace:: the ``posix_ipc`` semaphores
 
 Low-level API
 -------------

--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -337,7 +337,20 @@ In addition, **signac** also provides the :py:meth:`signac.Project.fn` method, w
     '/home/johndoe/my_project/foo.bar'
 
 
-Be careful when accessing the project-level data concurrently from different running jobs, as the underlying HDF5 file is locked by default, even when data is only being read. If data will only be read, the environment variable ``HDF5_USE_FILE_LOCKING`` can be set to ``FALSE`` to avoid this behaviour. For concurrent writing and reading, you can check |h5py_swmr|_, |multiprocessing_sync|_ or |posix_ipc_semaphores|_.
+.. warning::
+
+    Be careful when accessing the project-level data concurrently from different running jobs, as the underlying HDF5 file is locked by default, even when data is only being read.
+    If data will only be read, the environment variable ``HDF5_USE_FILE_LOCKING`` can be set to ``FALSE`` to avoid this behavior.
+    For concurrent writing and reading, try using one of the following approaches:
+
+    * :ref:`Single Writer Multiple Reader features of h5py <h5py:swmr>`
+    * |multiprocessing_sync|_
+    * |posix_ipc_semaphores|_
+
+.. _multiprocessing_sync: https://docs.python.org/3/library/multiprocessing.html#synchronization-between-processes
+.. |multiprocessing_sync| replace:: the synchronization primitives of the ``multiprocessing`` module
+.. _posix_ipc_semaphores: https://semanchuk.com/philip/posix_ipc/#semaphore
+.. |posix_ipc_semaphores| replace:: the ``posix_ipc`` semaphores
 
 .. _schema-detection:
 
@@ -512,10 +525,3 @@ Projects can also be synchronized using the Python API:
 .. code-block:: python
 
     project.sync('/remote/my_project')
-
-.. _h5py_swmr: https://docs.h5py.org/en/stable/swmr.html
-.. |h5py_swmr| replace:: the Single Writer Multiple Reader (SWMR) features of ``h5py``
-.. _multiprocessing_sync: https://docs.python.org/3/library/multiprocessing.html#synchronization-between-processes
-.. |multiprocessing_sync| replace:: the synchronization primitives of the ``multiprocessing`` module
-.. _posix_ipc_semaphores: http://semanchuk.com/philip/posix_ipc/#semaphore
-.. |posix_ipc_semaphores| replace:: the ``posix_ipc`` semaphores

--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -339,13 +339,13 @@ In addition, **signac** also provides the :py:meth:`signac.Project.fn` method, w
 
 .. warning::
 
-    Be careful when accessing the project-level data concurrently from different running jobs, as the underlying HDF5 file is locked by default, even when data is only being read. When trying to read concurrently you may get the following exception:
+    Be careful when accessing the project-level data concurrently from different running jobs, as the underlying HDF5 file is locked by default, even when data is only being read from. When trying to read concurrently you may get the following exception:
 
         .. code-block:: none
 
             OSError: Unable to open file (unable to lock file, errno = 11, error message = 'Resource temporarily unavailable').
 
-    If data will only be read, the environment variable ``HDF5_USE_FILE_LOCKING`` can be set to ``FALSE`` to avoid this behavior.
+    If data will **only** be read concurrently, the environment variable ``HDF5_USE_FILE_LOCKING`` can safely be set to ``FALSE`` to avoid this behavior.
     For concurrent writing and reading, try using one of the following approaches:
 
     * :ref:`Single Writer Multiple Reader features of h5py <h5py:swmr>`

--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -336,6 +336,9 @@ In addition, **signac** also provides the :py:meth:`signac.Project.fn` method, w
     >>> print(project.fn('foo.bar'))
     '/home/johndoe/my_project/foo.bar'
 
+
+Be careful when accessing the project-level data concurrently from different running jobs, as the underlying HDF5 file is locked by default, even when data is only being read. If data will only be read, the environment variable ``HDF5_USE_FILE_LOCKING`` can be set to ``FALSE`` to avoid this behaviour. For concurrent writing and reading, you can check |h5py_swmr|_, |multiprocessing_sync|_ or |posix_ipc_semaphores|_.
+
 .. _schema-detection:
 
 Schema Detection
@@ -509,3 +512,10 @@ Projects can also be synchronized using the Python API:
 .. code-block:: python
 
     project.sync('/remote/my_project')
+
+.. _h5py_swmr: https://docs.h5py.org/en/stable/swmr.html
+.. |h5py_swmr| replace:: the Single Writer Multiple Reader (SWMR) features of ``h5py``
+.. _multiprocessing_sync: https://docs.python.org/3/library/multiprocessing.html#synchronization-between-processes
+.. |multiprocessing_sync| replace:: the synchronization primitives of the ``multiprocessing`` module
+.. _posix_ipc_semaphores: http://semanchuk.com/philip/posix_ipc/#semaphore
+.. |posix_ipc_semaphores| replace:: the ``posix_ipc`` semaphores

--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -339,7 +339,12 @@ In addition, **signac** also provides the :py:meth:`signac.Project.fn` method, w
 
 .. warning::
 
-    Be careful when accessing the project-level data concurrently from different running jobs, as the underlying HDF5 file is locked by default, even when data is only being read.
+    Be careful when accessing the project-level data concurrently from different running jobs, as the underlying HDF5 file is locked by default, even when data is only being read. When trying to read concurrently you may get the following exception:
+
+        .. code-block:: none
+
+            OSError: Unable to open file (unable to lock file, errno = 11, error message = 'Resource temporarily unavailable').
+
     If data will only be read, the environment variable ``HDF5_USE_FILE_LOCKING`` can be set to ``FALSE`` to avoid this behavior.
     For concurrent writing and reading, try using one of the following approaches:
 


### PR DESCRIPTION
Accessing the project-level `data` attribute from multiple processes at the same time can give errors. After [being advised in the slack support channel](https://signac.slack.com/archives/CVC04S9TN/p1606922468155000) I thought it would be nice to mention this in the documentation.

## Description
Added a paragraph about how to circumvent this limitation, both in the multiple-readers case or the single-writer-multiple-readers case. I included links to the [`h5py` SWMR docs](https://docs.h5py.org/en/stable/swmr.html), the [`multiprocessing` synchronization primitives docs](https://docs.python.org/3/library/multiprocessing.html#synchronization-between-processes) and the [`posix_ipc` semaphores docs](http://semanchuk.com/philip/posix_ipc/#semaphore).

## Motivation and Context
Hopefully the next person to come across this problem can find the fix!

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-docs/blob/master/ContributorAgreement.md).
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md#code-style) of this project.
