### PR TITLE
Make reference name more specific to avoid conflicts.

### DIFF
--- a/docs/source/cluster_submission.rst
+++ b/docs/source/cluster_submission.rst
@@ -87,7 +87,7 @@ Without any argument the ``--bundle`` option will bundle **all** eligible job-op
 
     Recognizing that ``--bundle=1`` is the default option might help you to better understand the bundling concept.
 
-.. _directives:
+.. _cluster_submission_directives:
 
 Submission Directives
 =====================


### PR DESCRIPTION
## Description
Attempting to fix issue (we fail on warnings):

```
/home/docs/checkouts/readthedocs.org/user_builds/signac/checkouts/latest/docs/source/cluster_submission.rst:5: WARNING: Duplicate explicit target name: "directives".
```

https://readthedocs.org/projects/signac/builds/14007143/

Merging if docs build successfully.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-docs/blob/master/ContributorAgreement.md).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md#code-style) of this project.
