### PR TITLE
Update citation information.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,7 @@ repos:
       - id: bibtex-tidy
         args:
           - --omit=abstract,keywords,archiveprefix,mendeley-tags,pmid,eprint,arxivid
+          - --wrap=90
           - --curly
           - --numeric
           - --space=2

--- a/docs/source/acknowledge.bib
+++ b/docs/source/acknowledge.bib
@@ -1,0 +1,43 @@
+@article{signac_commat,
+  title = {Simple data and workflow management with the signac framework},
+  author = {Carl S. Adorf and Paul M. Dodd and Vyas Ramasubramani and Sharon C. Glotzer},
+  year = 2018,
+  journal = {Comput. Mater. Sci.},
+  volume = 146,
+  number = {C},
+  pages = {220--229},
+  doi = {10.1016/j.commatsci.2018.01.035}
+}
+@inproceedings{signac_scipy_2018,
+  title = {{s}ignac: {A} {P}ython framework for data and workflow management},
+  author = {
+    Vyas Ramasubramani and Carl S. Adorf and Paul M. Dodd and Bradley D. Dice and Sharon
+    C. Glotzer
+  },
+  year = 2018,
+  booktitle = {Proceedings of the 17th Python in Science Conference},
+  pages = {152--159},
+  doi = {10.25080/Majora-4af1f417-016}
+}
+@inproceedings{signac_scipy_2021,
+  title = {{s}ignac: {D}ata {M}anagement and {W}orkflows for {C}omputational {R}esearchers},
+  author = {
+    Bradley D. Dice and Brandon L. Butler and Vyas Ramasubramani and Alyssa Travitz and
+    Michael M. Henry and Hardik Ojha and Kelly L. Wang and Carl S. Adorf and Eric
+    Jankowski and Sharon C. Glotzer
+  },
+  year = 2021,
+  booktitle = {Proceedings of the 20th Python in Science Conference},
+  pages = {1--10}
+}
+@misc{signac_zenodo,
+  title = {glotzerlab/signac},
+  author = {
+    Carl S. Adorf and Vyas Ramasubramani and Bradley D. Dice and Michael M. Henry and
+    Paul M. Dodd and Sharon C. Glotzer
+  },
+  year = 2019,
+  month = feb,
+  doi = {10.5281/zenodo.2581327},
+  url = {https://doi.org/10.5281/zenodo.2581327}
+}

--- a/docs/source/acknowledge.rst
+++ b/docs/source/acknowledge.rst
@@ -37,7 +37,7 @@ If you make use of **signac-flow**, we also strongly recommend citing the follow
 
 --------
 
-If your paper makes use of the **signac-flow** features for aggregation, groups, and bundling or **signac** features for synced collections, consider citing:
+If your paper makes use of the **signac-flow** features for aggregation or groups, or **signac** features for synced collections, consider citing:
 
 .. bibliography::
     :filter: False

--- a/docs/source/acknowledge.rst
+++ b/docs/source/acknowledge.rst
@@ -17,62 +17,49 @@ Preferred Citation
 
 Please acknowledge the use of this software within the body of your publication by copying or adapting the following:
 
-*The computational workflow in general and data management in particular for this publication was primarily supported by the signac data management framework[1].*
+*The computational workflow and data management for this publication was supported by the signac data management framework [ADRG18].*
 
-  [1] Carl S. Adorf, Paul M. Dodd, Vyas Ramasubramani, and Sharon C. Glotzer. Simple data and workflow management with the signac framework. Computational Materials Science, 146(C):220-229, 2018. `DOI:10.1016/j.commatsci.2018.01.035 <https://doi.org/10.1016/j.commatsci.2018.01.035>`__.
+.. bibliography::
+    :filter: False
 
-If you make use of signac-flow, we also strongly recommend citing the following publication:
+    signac_commat
 
-  [2] Vyas Ramasubramani, Carl S. Adorf, Paul M. Dodd, Bradley D. Dice, and Sharon C. Glotzer. signac: A Python framework for data and workflow management. Proceedings of the 17th Python in Science Conference, 152-159, 2018. `DOI:10.25080/Majora-4af1f417-016 <https://doi.org/10.25080/Majora-4af1f417-016>`__.
+A preprint of this paper is also available as `arXiv:1611.03543 <https://arxiv.org/abs/1611.03543>`__.
+
+--------
+
+If you make use of **signac-flow**, we also strongly recommend citing the following publication:
+
+.. bibliography::
+    :filter: False
+
+    signac_scipy_2018
+
+--------
+
+If your paper makes use of the **signac-flow** features for aggregation, groups, and bundling or **signac** features for synced collections, consider citing:
+
+.. bibliography::
+    :filter: False
+
+    signac_scipy_2021
+
+--------
 
 If possible, we also recommend including a citation of the associated Zenodo resource:
 
-  [3] Carl S. Adorf, Vyas Ramasubramani, Bradley D. Dice, Michael M. Henry, Paul M. Dodd, & Sharon C. Glotzer. (2019, February 28). glotzerlab/signac (Version 1.0.0). Zenodo. `DOI:10.5281/zenodo.2581327 <https://doi.org/10.5281/zenodo.2581327>`__.
+.. bibliography::
+    :filter: False
 
-.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.2581327.svg
-   :target: https://doi.org/10.5281/zenodo.2581327
+    signac_zenodo
 
-A preprint of the paper published in the Journal of Computational Materials Science is available on the `arXiv <https://arxiv.org/abs/1611.03543>`_.
+--------
 
 To cite these references, you can use the following BibTeX entries:
 
-.. code-block:: bibtex
 
-    @article{signac_commat,
-      author        = {Carl S. Adorf and
-                       Paul M. Dodd and
-                       Vyas Ramasubramani and
-                       Sharon C. Glotzer},
-      title         = {Simple data and workflow management with the signac framework},
-      journal       = {Comput. Mater. Sci.},
-      volume        = {146},
-      number        = {C},
-      year          = {2018},
-      pages         = {220-229},
-      doi           = {10.1016/j.commatsci.2018.01.035}
-    }
-    @InProceedings{signac_scipy_2018,
-      author    = { Vyas Ramasubramani and Carl S. Adorf and Paul M. Dodd and Bradley D. Dice and Sharon C. Glotzer },
-      title     = { signac: A Python framework for data and workflow management },
-      booktitle = { Proceedings of the 17th Python in Science Conference },
-      pages     = { 152 - 159 },
-      year      = { 2018 },
-      editor    = { Fatih Akici and David Lippa and Dillon Niederhut and M. Pacer },
-      doi       = { 10.25080/Majora-4af1f417-016 }
-    }
-    @misc{signac_zenodo,
-      author       = {Carl S. Adorf and
-                      Vyas Ramasubramani and
-                      Bradley D. Dice and
-                      Michael M. Henry and
-                      Paul M. Dodd and
-                      Sharon C. Glotzer},
-      title        = {glotzerlab/signac},
-      month        = feb,
-      year         = 2019,
-      doi          = {10.5281/zenodo.2581327},
-      url          = {https://doi.org/10.5281/zenodo.2581327}
-    }
+.. literalinclude:: acknowledge.bib
+    :language: bibtex
 
 .. _badge:
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,7 @@ extensions = [
 ]
 
 # For sphinxcontrib.bibtex.
-bibtex_bibfiles = ["signac.bib"]
+bibtex_bibfiles = ["signac.bib", "acknowledge.bib"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/source/signac.bib
+++ b/docs/source/signac.bib
@@ -22,8 +22,17 @@
   issn = {2041-1723}
 }
 @article{Cummings2021,
-  title = {Open-source molecular modeling software in chemical engineering focusing on the {Molecular} {Simulation} {Design} {Framework}},
-  author = {Cummings, Peter T. and McCabe, Clare and Iacovella, Christopher R. and Ledeczi, Akos and Jankowski, Eric and Jayaraman, Arthi and Palmer, Jeremy C. and Maginn, Edward J. and Glotzer, Sharon C. and Anderson, Joshua A. and Siepmann, J. Ilja and Potoff, Jeffrey and Matsumoto, Ray A. and Gilmer, Justin B. and DeFever, Ryan S. and Singh, Ramanish and Crawford, Brad},
+  title = {
+    Open-source molecular modeling software in chemical engineering focusing on the
+    {Molecular} {Simulation} {Design} {Framework}
+  },
+  author = {
+    Cummings, Peter T. and McCabe, Clare and Iacovella, Christopher R. and Ledeczi, Akos
+    and Jankowski, Eric and Jayaraman, Arthi and Palmer, Jeremy C. and Maginn, Edward J.
+    and Glotzer, Sharon C. and Anderson, Joshua A. and Siepmann, J. Ilja and Potoff,
+    Jeffrey and Matsumoto, Ray A. and Gilmer, Justin B. and DeFever, Ryan S. and Singh,
+    Ramanish and Crawford, Brad
+  },
   year = 2021,
   month = jan,
   journal = {AIChE Journal},
@@ -56,7 +65,10 @@
   doi = {10.1103/PhysRevB.101.195104}
 }
 @article{Howard2019,
-  title = {Cross-stream migration of a {Brownian} droplet in a polymer solution under {Poiseuille} flow},
+  title = {
+    Cross-stream migration of a {Brownian} droplet in a polymer solution under
+    {Poiseuille} flow
+  },
   author = {P. Howard, Michael and M. Truskett, Thomas and Nikoubashman, Arash},
   year = 2019,
   month = mar,
@@ -68,7 +80,10 @@
 }
 @article{Musil2021,
   title = {Efficient implementation of atom-density representations},
-  author = {Musil, F\'{e}lix and Veit, Max and Goscinski, Alexander and Fraux, Guillaume and Willatt, Michael J. and Stricker, Markus and Junge, Till and Ceriotti, Michele},
+  author = {
+    Musil, F\'{e}lix and Veit, Max and Goscinski, Alexander and Fraux, Guillaume and
+    Willatt, Michael J. and Stricker, Markus and Junge, Till and Ceriotti, Michele
+  },
   year = 2021,
   month = mar,
   journal = {The Journal of Chemical Physics},
@@ -79,8 +94,14 @@
   issn = {0021-9606}
 }
 @article{Thomas2018,
-  title = {Routine million-particle simulations of epoxy curing with dissipative particle dynamics},
-  author = {Thomas, Stephen and Alberts, Monet and Henry, Michael M and Estridge, Carla E and Jankowski, Eric},
+  title = {
+    Routine million-particle simulations of epoxy curing with dissipative particle
+    dynamics
+  },
+  author = {
+    Thomas, Stephen and Alberts, Monet and Henry, Michael M and Estridge, Carla E and
+    Jankowski, Eric
+  },
   year = 2018,
   month = may,
   journal = {Journal of Theoretical and Computational Chemistry},
@@ -91,9 +112,15 @@
   issn = {0219-6336}
 }
 @article{Thompson2019,
-  title = {Scalable {{Screening}} of {{Soft Matter}}: {{A Case Study}} of {{Mixtures}} of {{Ionic Liquids}} and {{Organic Solvents}}},
+  title = {
+    Scalable {{Screening}} of {{Soft Matter}}: {{A Case Study}} of {{Mixtures}} of
+    {{Ionic Liquids}} and {{Organic Solvents}}
+  },
   shorttitle = {Scalable {{Screening}} of {{Soft Matter}}},
-  author = {Thompson, Matthew W. and Matsumoto, Ray and Sacci, Robert L. and Sanders, Nicolette C. and Cummings, Peter T.},
+  author = {
+    Thompson, Matthew W. and Matsumoto, Ray and Sacci, Robert L. and Sanders, Nicolette
+    C. and Cummings, Peter T.
+  },
   year = 2019,
   month = jan,
   journal = {J. Phys. Chem. B},
@@ -105,8 +132,15 @@
   issn = {1520-6106}
 }
 @article{Thompson2020,
-  title = {Towards molecular simulations that are transparent, reproducible, usable by others, and extensible ({TRUE})},
-  author = {Thompson, Matthew W. and Gilmer, Justin B. and Matsumoto, Ray A. and Quach, Co D. and Shamaprasad, Parashara and Yang, Alexander H. and Iacovella, Christopher R. and McCabe, Clare and Cummings, Peter T.},
+  title = {
+    Towards molecular simulations that are transparent, reproducible, usable by others,
+    and extensible ({TRUE})
+  },
+  author = {
+    Thompson, Matthew W. and Gilmer, Justin B. and Matsumoto, Ray A. and Quach, Co D. and
+    Shamaprasad, Parashara and Yang, Alexander H. and Iacovella, Christopher R. and
+    McCabe, Clare and Cummings, Peter T.
+  },
   year = 2020,
   month = apr,
   journal = {Molecular Physics},


### PR DESCRIPTION
## Description
Adds new citation information for the SciPy 2021 proceedings paper (no DOI is available yet). For now, I recommend citing the new SciPy paper only in cases where the content specifically references the new features that have been recently added:

> If your paper makes use of the signac-flow features for aggregation, groups, and bundling or signac features for synced collections, consider citing:

I reorganized citation information to use BibTeX files that match the format of the "Scientific Papers" page.

I made the recommended citation statement shorter, since I have seen several users (including myself) adapt the statement in this way.

Lastly, I edited some bibtex-tidy pre-commit settings to wrap content at 90 characters. That's what fits on screen (on a desktop or laptop) without creating a scroll bar.

Compare the ReadTheDocs build to the current page: https://docs.signac.io/en/latest/acknowledge.html

## Motivation and Context
Updating citation information to make it clearer how to cite the software.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-docs/blob/master/ContributorAgreement.md).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md#code-style) of this project.
