### PR TITLE
Clarify limits of submit --bundle --parallel

### DIFF
--- a/docs/source/cluster_submission.rst
+++ b/docs/source/cluster_submission.rst
@@ -88,7 +88,7 @@ Without any argument, the ``--bundle`` option will bundle **all** eligible job-o
     Recognizing that ``--bundle=1`` is the default option might help you to better understand the bundling concept.
 
 By default, the submit command will run bundled job-operations in serial.
-It is possible to run multiple CPU processes in parallel, as long as the operating system assigns running threads to any available CPU cores, which is not the default behavior on all compute clusters.
+It is possible to run bundled jobs in parallel (when executing on the CPU), as long as the operating system assigns running threads to any available CPU cores, which is **not** the default behavior on all compute clusters.
 The ``--parallel`` flag will start the bundled job-operations and run them as background processes. Ensure that the processes are correctly assigned to the requested resources before using this option.
 
 .. warning::

--- a/docs/source/cluster_submission.rst
+++ b/docs/source/cluster_submission.rst
@@ -93,7 +93,7 @@ The ``--parallel`` flag will start the bundled job-operations and run them as ba
 
 .. warning::
 
-    The ``--parallel`` option will not distribute operations among multiple GPUs. Use aggregation instead. (TODO: link to tutorial)
+    The ``--parallel`` option will not distribute operations among multiple GPUs. Use :ref:`aggregation<_aggregation>` instead.
     To distribute across multiple GPUs, clusters may require a split MPI communicator.
     An example of this behavior can be found in the `signac-examples project flow.aggregation-mpi <https://github.com/glotzerlab/signac-examples/tree/master/projects/flow.aggregation-mpi>`__.
 

--- a/docs/source/cluster_submission.rst
+++ b/docs/source/cluster_submission.rst
@@ -93,7 +93,7 @@ The ``--parallel`` flag will start the bundled job-operations and run them as ba
 
 .. warning::
 
-    The ``--parallel`` option will not distribute operations among multiple GPUs. Use :ref:`aggregation<_aggregation>` instead.
+    The ``--parallel`` option will not distribute operations among multiple GPUs. Use :ref:`aggregation` instead.
     To distribute across multiple GPUs, clusters may require a split MPI communicator.
     An example of this behavior can be found in the `signac-examples project flow.aggregation-mpi <https://github.com/glotzerlab/signac-examples/tree/master/projects/flow.aggregation-mpi>`__.
 

--- a/docs/source/cluster_submission.rst
+++ b/docs/source/cluster_submission.rst
@@ -71,10 +71,8 @@ Bundling
 ========
 
 By default, all eligible job-operations will be submitted as separate cluster jobs.
-This is usually the best model for clusters that provide shared compute partitions
-because it allows the cluster scheduler to optimize the scheduling of your job.
-However, sometimes it is beneficial to execute multiple operations within one cluster job,
-like if the compute cluster can only make reservation for full nodes or if there is a limit to the number of cluster jobs you can submit to the cluster scheduler's queue.
+This is usually the best model for clusters that provide shared compute partitions because it allows the cluster scheduler to optimize the scheduling of your job.
+However, sometimes it is beneficial to execute multiple operations within one cluster job, like if the compute cluster can only make reservation for full nodes or if there is a limit to the number of cluster jobs you can submit to the cluster scheduler's queue.
 
 .. _cluster_submission_directives:
 
@@ -91,7 +89,8 @@ Without any argument, the ``--bundle`` option will bundle **all** eligible job-o
 
     Recognizing that ``--bundle=1`` is the default option might help you to better understand the bundling concept.
 
-By default, the submit command will run bundled job-operations in serial. It is possible to run multiple CPU processes in parallel, as long as the operating system assigns running threads to any available CPU cores, which is not available on all compute clusters.
+By default, the submit command will run bundled job-operations in serial.
+It is possible to run multiple CPU processes in parallel, as long as the operating system assigns running threads to any available CPU cores, which is not the default behavior on all compute clusters.
 The ``--parallel`` flag will start the bundled job-operations and run them as background processes. Ensure that the processes are correctly assigned to the requested resources before using this option.
 
 .. warning::

--- a/docs/source/cluster_submission.rst
+++ b/docs/source/cluster_submission.rst
@@ -67,27 +67,37 @@ For example the following command would submit up to 5 ``hello`` operations, whe
     Use the ``--pretend`` option to preview the generated submission scripts on screen instead of submitting them.
 
 
-Parallelization and Bundling
-============================
+Bundling
+========
 
-By default all eligible job-operations will be submitted as separate cluster jobs.
-This is usually the best model for clusters that provide shared compute partitions.
-However, sometimes it is beneficial to execute multiple operations within one cluster job, especially if the compute cluster can only make reservation for full nodes.
+By default, all eligible job-operations will be submitted as separate cluster jobs.
+This is usually the best model for clusters that provide shared compute partitions
+because it allows the cluster scheduler to optimize the scheduling of your job.
+However, sometimes it is beneficial to execute multiple operations within one cluster job,
+like if the compute cluster can only make reservation for full nodes or if there is a limit to the number of cluster jobs you can submit to the cluster scheduler's queue.
 
-You can place multiple job-operations within one cluster submission with the ``--bundle`` option.
-For example, the following command will bundle up to 5 job-operations to be executed in parallel into a single cluster submission:
+.. _cluster_submission_directives:
+
+You can execute multiple job-operations in serial within one cluster submission with the ``--bundle`` option.
+For example, the following command will bundle up to five job-operations to be executed into a single cluster submission:
 
 .. code-block:: bash
 
-    ~/my_project $ python project.py submit --bundle=5 --parallel
+    ~/my_project $ python project.py submit --bundle=5
 
-Without any argument the ``--bundle`` option will bundle **all** eligible job-operations into a single cluster job.
+Without any argument, the ``--bundle`` option will bundle **all** eligible job-operations into a single cluster job.
 
 .. tip::
 
     Recognizing that ``--bundle=1`` is the default option might help you to better understand the bundling concept.
 
-.. _cluster_submission_directives:
+By default, the submit command will run bundled job-operations in serial. It is possible to run multiple CPU processes in parallel, as long as the operating system assigns running threads to any available CPU cores, which is not available on all compute clusters.
+The ``--parallel`` flag will start the bundled job-operations and run them as background processes. Ensure that the processes are correctly assigned to the requested resources before using this option.
+
+.. warning::
+
+   The ``--parallel`` flag will not distribute operations among multiple GPUs. Use aggregation instead. (TODO: link to tutorial)
+
 
 Submission Directives
 =====================

--- a/docs/source/cluster_submission.rst
+++ b/docs/source/cluster_submission.rst
@@ -95,7 +95,7 @@ The ``--parallel`` flag will start the bundled job-operations and run them as ba
 
 .. warning::
 
-   The ``--parallel`` flag will not distribute operations among multiple GPUs. Use aggregation instead. (TODO: link to tutorial)
+   The ``--parallel`` option will not distribute operations among multiple GPUs. Use aggregation instead. (TODO: link to tutorial)
 
 
 Submission Directives

--- a/docs/source/cluster_submission.rst
+++ b/docs/source/cluster_submission.rst
@@ -93,7 +93,9 @@ The ``--parallel`` flag will start the bundled job-operations and run them as ba
 
 .. warning::
 
-   The ``--parallel`` option will not distribute operations among multiple GPUs. Use aggregation instead. (TODO: link to tutorial)
+    The ``--parallel`` option will not distribute operations among multiple GPUs. Use aggregation instead. (TODO: link to tutorial)
+    To distribute across multiple GPUs, clusters may require a split MPI communicator.
+    An example of this behavior can be found in the `signac-examples project flow.aggregation-mpi <https://github.com/glotzerlab/signac-examples/tree/master/projects/flow.aggregation-mpi>`__.
 
 .. _cluster_submission_directives:
 

--- a/docs/source/cluster_submission.rst
+++ b/docs/source/cluster_submission.rst
@@ -74,10 +74,8 @@ By default, all eligible job-operations will be submitted as separate cluster jo
 This is usually the best model for clusters that provide shared compute partitions because it allows the cluster scheduler to optimize the scheduling of your job.
 However, sometimes it is beneficial to execute multiple operations within one cluster job, like if the compute cluster can only make reservation for full nodes or if there is a limit to the number of cluster jobs you can submit to the cluster scheduler's queue.
 
-.. _cluster_submission_directives:
-
-You can execute multiple job-operations in serial within one cluster submission with the ``--bundle`` option.
-For example, the following command will bundle up to five job-operations to be executed into a single cluster submission:
+You can execute multiple job-operations in serial per cluster job submission with the ``--bundle`` option.
+For example, the following command will bundle up to five job-operations to be executed in each cluster submission:
 
 .. code-block:: bash
 
@@ -97,6 +95,7 @@ The ``--parallel`` flag will start the bundled job-operations and run them as ba
 
    The ``--parallel`` option will not distribute operations among multiple GPUs. Use aggregation instead. (TODO: link to tutorial)
 
+.. _cluster_submission_directives:
 
 Submission Directives
 =====================


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

Users often want to use the `submit --bundle --parallel` flag on GPU clusters, but this doesn't work. Update documentation so users know its limits.

## Description
<!-- Describe your changes in detail -->

I explain bundling first without the `--parallel` flag.

I moved the explanation of `--parallel` to the end and introduced it specifically for CPU nodes.

Added a warning for GPU nodes. We should link to the aggregation tutorial eventually.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
See for example #27 or discussion at [glotzerlab/signac#593
](https://github.com/glotzerlab/signac-flow/pull/594)

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [ ] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-docs/blob/master/ContributorAgreement.md).
- [ ] My code follows the [code style guideline](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md#code-style) of this project.
