### PR TITLE
Fixed import typo: with_job is located in root flow module

### DIFF
--- a/docs/source/flow-project.rst
+++ b/docs/source/flow-project.rst
@@ -176,10 +176,12 @@ If we implemented and integrated the operation and condition functions correctly
     For example:
 
     .. code-block:: python
+        
+        from flow import with_job
 
         @MyProject.operation
         @MyProject.post(greeted)
-        @MyProject.with_job
+        @with_job
         def hello(job):
             with open('hello.txt', 'w') as file:
                 file.write('world!\n')


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
The `with_job` decorator was used as an attribute of the `FlowProject` class. It is indicated correctly in other places, so maybe it was correct before but this instance was not updated in the docs. I checked and all mentions of `with_job` are now correct.

## Motivation and Context
The code is incorrect, as it does not correlate with the current API.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-docs/blob/master/ContributorAgreement.md).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md#code-style) of this project.
