### PR TITLE
Updated Grouping Operations Documentation

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -379,8 +379,8 @@ Grouping Operations
 -------------------
 
 If we wanted to submit :code:`compute_volume` and
-:code:`store_volume_in_document` together to run in series, we currently couldn't, even though we
-know that :code:`store_volume_in_document` can run immediately after
+:code:`store_volume_in_json_file` together to run in series, we currently couldn't, even though we
+know that :code:`store_volume_in_json_file` can run immediately after
 :code:`compute_volume`. With the :py:class:`FlowGroup` class, we can group the
 two operations together and submit any job that is ready to run
 :code:`compute_volume`. To do this, we create a group and decorate the operations

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -391,7 +391,7 @@ with it.
     # project.py
     from flow import FlowProject
     import json
-    
+
     volume_group = FlowProject.make_group(name='volume')
 
     @FlowProject.label

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -390,7 +390,8 @@ with it.
 
     # project.py
     from flow import FlowProject
-
+    import json
+    
     volume_group = FlowProject.make_group(name='volume')
 
     @FlowProject.label


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
Added `import json`  in **Grouping Operations** documentation

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

1. `json` is being used in the code sample but was not imported.
2.  Changed `store_volume_in_document` to `store_volume_in_json_file` in the grouping documentation, because the function used in the following code sample is `store_volume_in_json_file` 

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-docs/blob/master/ContributorAgreement.md).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md#code-style) of this project.