### PR TITLE
Blacken docs.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,10 @@ repos:
     hooks:
       - id: nbqa-black
       - id: nbqa-pyupgrade
+  - repo: https://github.com/asottile/blacken-docs
+    rev: v1.12.1
+    hooks:
+      - id: blacken-docs
   - repo: https://github.com/FlamingTempura/bibtex-tidy
     rev: 'v1.8.5'
     hooks:

--- a/docs/source/aggregation.rst
+++ b/docs/source/aggregation.rst
@@ -21,17 +21,21 @@ See also the Python documentation about :ref:`argument unpacking <python:tut-unp
     # project.py
     from flow import FlowProject, aggregator
 
+
     class Project(FlowProject):
         pass
+
 
     @aggregator()
     @Project.operation
     def op1(*jobs):
         print("Number of jobs in aggregate:", len(jobs))
 
+
     @Project.operation
     def op2(job):
         pass
+
 
     if __name__ == "__main__":
         Project().main()
@@ -167,10 +171,13 @@ By default, no aggregation takes place for a :py:class:`FlowGroup`.
     # project.py
     from flow import FlowProject, aggregator
 
+
     class Project(FlowProject):
         pass
 
+
     group = Project.make_group("agg-group", group_aggregator=aggregator())
+
 
     @group
     @aggregator()
@@ -178,10 +185,12 @@ By default, no aggregation takes place for a :py:class:`FlowGroup`.
     def op1(*jobs):
         pass
 
+
     @group
     @Project.operation
     def op2(*jobs):
         pass
+
 
     if __name__ == "__main__":
         Project().main()

--- a/docs/source/cluster_submission.rst
+++ b/docs/source/cluster_submission.rst
@@ -101,10 +101,11 @@ For example, to specify that a parallelized operation requires **4** processing 
     from flow import FlowProject
     from multiprocessing import Pool
 
+
     @FlowProject.operation.with_directives({"np": 4})
     def hello(job):
         with Pool(4) as pool:
-          print("hello", job)
+            print("hello", job)
 
 .. note::
 

--- a/docs/source/collections.rst
+++ b/docs/source/collections.rst
@@ -30,7 +30,7 @@ For this, simply *open* a file like this:
 
 .. code-block:: python
 
-    with Collection.open('my_collection.txt') as collection:
+    with Collection.open("my_collection.txt") as collection:
         pass
 
 A collection file by default is openend in *append plus* mode, that means it is opened for both reading and writing.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -84,10 +84,10 @@ You can omit the ``-p/--password`` argument, in which case the password will not
 
 We can now connect to this host with:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> import signac
-    >>> db = signac.get_database('mydatabase', hostname='example')
+    >>> db = signac.get_database("mydatabase", hostname="example")
 
 The ``hostname`` argument defaults to the first configured host and can always be omitted if there is only one configured host.
 

--- a/docs/source/dashboard.rst
+++ b/docs/source/dashboard.rst
@@ -18,6 +18,7 @@ You can start a dashboard to visualize **signac** project data in the browser, b
 .. code-block:: python
 
     from signac_dashboard import Dashboard
+
     Dashboard().main()
 
 Start a Dashboard
@@ -30,7 +31,7 @@ The code below will open a dashboard for an newly-initialized (empty) project, w
     from signac_dashboard import Dashboard
     from signac_dashboard.modules import ImageViewer
 
-    if __name__ == '__main__':
+    if __name__ == "__main__":
         Dashboard(modules=[ImageViewer()]).main()
 
 Then launch the dashboard with ``python dashboard.py run``.
@@ -48,11 +49,11 @@ By creating a class that inherits from :py:class:`~signac_dashboard.Dashboard` (
 .. code-block:: python
 
     class MyDashboard(Dashboard):
-
         def job_title(self, job):
-            return 'Concentration(A) = {}'.format(job.sp['conc_A'])
+            return "Concentration(A) = {}".format(job.sp["conc_A"])
 
-    if __name__ == '__main__':
+
+    if __name__ == "__main__":
         MyDashboard().main()
 
 .. _dashboard-remote-ssh:

--- a/docs/source/environments.rst
+++ b/docs/source/environments.rst
@@ -49,8 +49,8 @@ This is an example for a typical environment class definition:
 
       class MyUniversityCluster(flow.environment.DefaultSlurmEnvironment):
 
-          hostname_pattern = r'.*\.mycluster\.university\.edu$'  # Matches names like login.mycluster.university.edu
-          template = 'myuniversity-mycluster.sh'
+          hostname_pattern = r".*\.mycluster\.university\.edu$"  # Matches names like login.mycluster.university.edu
+          template = "myuniversity-mycluster.sh"
 
 Then, add the ``myuniversity-mycluster.sh`` template script to the ``templates/`` directory within your project root directory.
 

--- a/docs/source/flow-group.rst
+++ b/docs/source/flow-group.rst
@@ -34,22 +34,27 @@ group named ``ex`` to contain operations ``op1`` and ``op2``.
     # project.py
     from flow import FlowProject
 
+
     class Project(FlowProject):
         pass
 
-    ex = Project.make_group(name='ex')
+
+    ex = Project.make_group(name="ex")
+
 
     @ex
     @Project.operation
     def op1(job):
         pass
 
+
     @ex
     @Project.operation
     def op2(job):
         pass
 
-    if __name__ == '__main__':
+
+    if __name__ == "__main__":
         Project().main()
 
 A group is eligible if
@@ -85,10 +90,13 @@ In the following example, :code:`op1` requests one GPU if run by itself or two G
     # project.py
     from flow import FlowProject
 
+
     class Project(FlowProject):
         pass
 
-    ex = Project.make_group(name='ex')
+
+    ex = Project.make_group(name="ex")
+
 
     @ex.with_directives({"ngpu": 2})
     @Project.operation.with_directives({"ngpu": 1})
@@ -96,5 +104,5 @@ In the following example, :code:`op1` requests one GPU if run by itself or two G
         pass
 
 
-    if __name__ == '__main__':
+    if __name__ == "__main__":
         Project().main()

--- a/docs/source/flow-project.rst
+++ b/docs/source/flow-project.rst
@@ -19,10 +19,12 @@ To implement an automated workflow using **signac-flow**, we create a subclass o
     # project.py
     from flow import FlowProject
 
+
     class MyProject(FlowProject):
         pass
 
-    if __name__ == '__main__':
+
+    if __name__ == "__main__":
         MyProject().main()
 
 .. tip::
@@ -62,9 +64,9 @@ Let's initialize a project with a few jobs, by executing the following ``init.py
 
     import signac
 
-    project = signac.init_project('MyProject')
+    project = signac.init_project("MyProject")
     for i in range(10):
-        project.open_job({'a': i}).init()
+        project.open_job({"a": i}).init()
 
 A very simple *operation*, which creates a file called ``hello.txt`` within a job's workspace directory, could be implemented like this:
 
@@ -74,18 +76,20 @@ A very simple *operation*, which creates a file called ``hello.txt`` within a jo
 
     from flow import FlowProject
 
+
     class MyProject(FlowProject):
         pass
 
+
     @MyProject.operation
     def hello(job):
-        print('hello', job)
+        print("hello", job)
         with job:
-            with open('hello.txt', 'w') as file:
-                file.write('world!\n')
+            with open("hello.txt", "w") as file:
+                file.write("world!\n")
 
 
-    if __name__ == '__main__':
+    if __name__ == "__main__":
         MyProject().main()
 
 
@@ -104,7 +108,7 @@ To do this, we need to create a condition function named ``greeted`` that tells 
 .. code-block:: python
 
     def greeted(job):
-        return job.isfile('hello.txt')
+        return job.isfile("hello.txt")
 
 To complete this component of the workflow, we use the :py:meth:`~flow.FlowProject.post` decorator function to specify that the ``hello`` operation function should only be executed if the ``greeted`` condition is *not* met.
 
@@ -121,18 +125,18 @@ The entirety of the code is as follows:
 
 
     def greeted(job):
-        return job.isfile('hello.txt')
+        return job.isfile("hello.txt")
 
 
     @MyProject.operation
     @MyProject.post(greeted)
     def hello(job):
         with job:
-            with open('hello.txt', 'w') as file:
-                file.write('world!\n')
+            with open("hello.txt", "w") as file:
+                file.write("world!\n")
 
 
-    if __name__ == '__main__':
+    if __name__ == "__main__":
         MyProject().main()
 
 We can define both :py:meth:`~flow.FlowProject.pre` and :py:meth:`~flow.FlowProject.post` conditions, which allow us to define arbitrary workflows as a `directed acyclic graph <https://en.wikipedia.org/wiki/Directed_acyclic_graph>`__.
@@ -179,12 +183,13 @@ If we implemented and integrated the operation and condition functions correctly
 
         from flow import with_job
 
+
         @MyProject.operation
         @MyProject.post(greeted)
         @with_job
         def hello(job):
-            with open('hello.txt', 'w') as file:
-                file.write('world!\n')
+            with open("hello.txt", "w") as file:
+                file.write("world!\n")
 
     Is the same as:
 
@@ -194,8 +199,8 @@ If we implemented and integrated the operation and condition functions correctly
         @MyProject.post(greeted)
         def hello(job):
             with job:
-                with open('hello.txt', 'w') as file:
-                    file.write('world!\n')
+                with open("hello.txt", "w") as file:
+                    file.write("world!\n")
 
     This saves a level of indentation and makes it clear the entire operation should take place in the ``job`` context.
     ``@with_job`` also works with the ``@cmd`` decorator but **must** be used first, e.g.:
@@ -221,7 +226,7 @@ We can convert any condition function into a label function by adding the :py:me
 
     @MyProject.label
     def greeted(job):
-        return job.isfile('hello.txt')
+        return job.isfile("hello.txt")
 
 We will reset the workflow for only a few jobs to get a more interesting *status* view:
 

--- a/docs/source/hooks.rst
+++ b/docs/source/hooks.rst
@@ -59,14 +59,18 @@ Otherwise, ``store_success_to_doc`` will be executed.
     # project.py
     from flow import FlowProject
 
+
     class Project(FlowProject):
         pass
 
+
     def store_success_to_doc(operation_name, job):
-        job.doc.update({f'{operation_name}_success': True})
+        job.doc.update({f"{operation_name}_success": True})
+
 
     def store_error_to_doc(operation_name, error, job):
-        job.doc.update({f'{operation_name}_success': False})
+        job.doc.update({f"{operation_name}_success": False})
+
 
     @Project.operation
     @Project.operation_hooks.on_success(store_success_to_doc)
@@ -75,7 +79,8 @@ Otherwise, ``store_success_to_doc`` will be executed.
         if job.sp.a == 0:
             raise RuntimeError("Cannot process jobs with a == 0.")
 
-    if __name__ == '__main__':
+
+    if __name__ == "__main__":
         Project().main()
 
 
@@ -98,28 +103,34 @@ The hook appends the current time to a list in the job document that is named ba
 
     from flow import FlowProject
 
+
     class Project(FlowProject):
         pass
 
+
     @Project.operation
-    @Project.post.true('test_ran')
+    @Project.post.true("test_ran")
     def do_operation(job):
         job.doc.test_ran = True
 
+
     @Project.operation
     @Project.pre.after(do_operation)
-    @Project.post.false('test_ran')
+    @Project.post.false("test_ran")
     def undo_operation(job):
         job.doc.test_ran = False
 
+
     def track_start_time(operation_name, job):
         import time
-        current_time = time.strftime('%b %d, %Y at %l:%M:%S %p %Z')
-        doc_key = f'{operation_name}_start_times'
+
+        current_time = time.strftime("%b %d, %Y at %l:%M:%S %p %Z")
+        doc_key = f"{operation_name}_start_times"
         job.doc.setdefault(doc_key, [])
         job.doc[doc_key].append(current_time)
 
-    if __name__ == '__main__':
+
+    if __name__ == "__main__":
         project = Project()
         project.project_hooks.on_start = [track_start_time]
         project.main()
@@ -132,35 +143,41 @@ A custom set of hooks may also be installed at the project level by a custom ``i
     # project.py
     from flow import FlowProject
 
+
     class Project(FlowProject):
         pass
 
+
     @Project.operation
-    @Project.post.true('test_ran')
+    @Project.post.true("test_ran")
     def do_operation(job):
         job.doc.test_ran = True
 
+
     # Define custom hooks class.
     class ProjectHooks:
-
         def set_job_doc(self, key):
             def set_true(operation_name, job):
                 job.doc[f"{operation_name}_{key}"] = True
+
             return set_true
 
         def set_job_doc_with_error(self, key):
             def set_false(operation_name, error, job):
                 job.doc[f"{operation_name}_{key}"] = False
+
             return set_false
 
         def install_hooks(self, project):
             project.project_hooks.on_start.append(self.set_job_doc("start"))
             project.project_hooks.on_success.append(self.set_job_doc("success"))
-            project.project_hooks.on_exception.append(self.set_job_doc_with_error("success"))
+            project.project_hooks.on_exception.append(
+                self.set_job_doc_with_error("success")
+            )
             return project
 
 
-    if __name__ == '__main__':
+    if __name__ == "__main__":
         project = Project()
         project = ProjectHooks().install_hooks(project)
         project.main()

--- a/docs/source/jobs.rst
+++ b/docs/source/jobs.rst
@@ -58,10 +58,10 @@ This subdirectory is named by the *job id*, therefore guaranteeing a unique file
 Both the state point and the job id are equivalent addresses for jobs in the data space.
 To access or modify a data point, obtain an instance of :py:class:`Job` by passing the associated metadata as a mapping of key-value pairs (for example, as an instance of :py:class:`dict`) into the :py:meth:`~signac.Project.open_job` method.
 
-.. code-block:: python
+.. code-block:: pycon
 
     # Define a state point:
-    >>> statepoint = {'a': 0}
+    >>> statepoint = {"a": 0}
     # Get the associated job:
     >>> job = project.open_job(statepoint)
     >>> print(job.id)
@@ -72,9 +72,9 @@ In general an instance of :py:class:`Job` only gives you a handle to a Python ob
 To create the underlying workspace directory and thus make the job part of the data space, you must *initialize* it.
 You can initialize a job **explicitly**, by calling the :py:meth:`Job.init` method, or **implicitly**, by either accessing the job's :ref:`job document <project-job-document>` or by switching into the job's workspace directory.
 
-.. code-block:: python
+.. code-block:: pycon
 
-    >>> job = project.open_job({'a': 2})
+    >>> job = project.open_job({"a": 2})
     # Job does not exist yet
     >>> job in project
     False
@@ -85,7 +85,7 @@ You can initialize a job **explicitly**, by calling the :py:meth:`Job.init` meth
 
 Once a job has been initialized, it may also be *opened by id* as follows (initialization is required because prior to initialization the job id has not yet been calculated):
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> job.init()
     >>> job2 = project.open_job(id=job.id)
@@ -94,7 +94,7 @@ Once a job has been initialized, it may also be *opened by id* as follows (initi
 
 Whether a job is opened by state point or job id, an instance of :py:class:`Job` can always be used to retrieve the associated *state point*, the *job id*, and the *workspace* directory with the :py:attr:`Job.statepoint`, :py:meth:`Job.get_id`, and :py:meth:`Job.workspace` methods, respectively:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> print(job.statepoint())
     {'a': 0}
@@ -107,9 +107,9 @@ Evidently, the job's workspace directory is a subdirectory of the project's work
 We can use the :py:meth:`Job.fn` function to prepend the workspace path to a file name; ``job.fn(filename)`` is equivalent to ``os.path.join(job.workspace(), filename)``.
 This function makes it easy to create or open files which are associated with the job:
 
-.. code-block:: python
+.. code-block:: pycon
 
-    >>> print(job.fn('newfile.txt'))
+    >>> print(job.fn("newfile.txt"))
     '/home/johndoe/my_project/workspace/9bfd29df07674bc4aa960cf661b5acd2/newfile.txt'
 
 For convenience, the *state point* may also be accessed via the :py:attr:`Job.statepoint` or :py:attr:`Job.sp` attributes, e.g., the value for ``a`` can be printed using either ``print(job.sp.a)`` or ``print(job.statepoint.a)``.
@@ -148,34 +148,34 @@ To **add a new key** ``b`` to all existing *state points* that do not currently 
 .. code-block:: python
 
     for job in project:
-        job.sp.setdefault('b', 0)
+        job.sp.setdefault("b", 0)
 
 **Renaming** a state point key from ``b`` to ``c``:
 
 .. code-block:: python
 
     for job in project:
-        assert 'c' not in job.sp
-        job.sp.c = job.statepoint.pop('b')
+        assert "c" not in job.sp
+        job.sp.c = job.statepoint.pop("b")
 
 To **remove** a state point key ``c``:
 
 .. code-block:: python
 
     for job in project:
-        if 'c' in job.sp:
-            del job.sp['c']
+        if "c" in job.sp:
+            del job.sp["c"]
 
 You can modify **nested** *state points* in-place, but you will need to use dictionaries to add new nested keys, e.g.:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> job.statepoint()
     {'a': 0}
     >>> job.sp.b.c = 0  # <-- will raise an AttributeError!!
 
     # Instead:
-    >>> job.sp.b = {'c': 0}
+    >>> job.sp.b = {"c": 0}
 
     # Now you can modify in-place:
     >>> job.sp.b.c = 1
@@ -202,19 +202,19 @@ You can access it via the :py:attr:`Job.document` or the :py:attr:`Job.doc` attr
 
 .. _`JSON`: https://en.wikipedia.org/wiki/JSON
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> job = project.open_job(statepoint)
-    >>> job.doc['hello'] = 'world'
+    >>> job.doc["hello"] = "world"
     # or equivalently
-    >>> job.doc.hello = 'world'
+    >>> job.doc.hello = "world"
 
 Just like the job *state point*, individual keys may be accessed either as attributes or through a functional interface.
 The following examples are all equivalent:
 
-.. code-block:: python
+.. code-block:: pycon
 
-    >>> print(job.document().get('hello'))
+    >>> print(job.document().get("hello"))
     world
     >>> print(job.document.hello)
     world
@@ -256,35 +256,38 @@ Reading and Writing data
 
 An example of storing data:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> import numpy as np
     >>> job = project.open_job(statepoint)
-    >>> job.data['x'] = np.ones([10, 3, 4])
+    >>> job.data["x"] = np.ones([10, 3, 4])
 
 
 Just like the job *state point* and *document*, individual keys may be accessed either as attributes or through a functional interface:
 
 To access data as an attribute:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> with job.data:
     ...     x = job.data.x[:]
+    ...
 
 To access data as a key:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> with job.data:
-    ...     x = job.data['x'][:]
+    ...     x = job.data["x"][:]
+    ...
 
 Through a functional interface:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> with job.data:
-    ...     x = job.data.get('x')[:]
+    ...     x = job.data.get("x")[:]
+    ...
 
 .. tip::
 
@@ -301,28 +304,31 @@ That is important to enable the storage of massive arrays that do not necessaril
 For fast and efficient data access, NumPy slicing syntax may be used to access data.
 Here are a few examples for accessing a three-dimensional array with outputs omitted:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> with job.data:
     ...     job.data.x[0, 0, 0]
     ...     job.data.x[1:3, 0, :]
     ...     job.data.x[:, 1, 3]
+    ...
 
 To load entire arrays to memory, NumPy slicing syntax may be used:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> with job.data:
     ...     x = job.data.x[:]
+    ...
 
 NumPy slicing (ie. the ``[:]`` operator) may be used to load array-like and text data.
 It cannot be used to load scalar values.
 Instead, the explicit memory copy operator ``[()]`` may be used instead of NumPy slicing to load entire arrays or scalars to memory:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> with job.data:
     ...     x = job.data.x[()]
+    ...
 
 A caveat of the explicit memory copy operator ``[()]`` is that it cannot be used to load strings.
 Generally, the :py:attr:`job.data` container is intended for large numerical or text data.
@@ -335,20 +341,21 @@ Data organization
 The `HDF5`_ format used by :attr:`job.data` allows for hierarchical organization of data.
 Data may be stored in folder-like *groups*:
 
-.. code-block:: python
+.. code-block:: pycon
 
-    >>> job.data['group/subgroup_1'] = np.ones([10, 3, 2])
-    >>> job.data['group/subgroup_2'] = np.ones([10, 1, 2])
+    >>> job.data["group/subgroup_1"] = np.ones([10, 3, 2])
+    >>> job.data["group/subgroup_2"] = np.ones([10, 1, 2])
 
 Data may be accessed as attributes, keys, or through a functional interface.
 The following examples are all equivalent:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> with job.data:
     ...     job.data.group.subgroup_1[:]
-    ...     job.data['group/subgroup_1'][:]
-    ...     job.data.get('group/subgroup_1')[:]
+    ...     job.data["group/subgroup_1"][:]
+    ...     job.data.get("group/subgroup_1")[:]
+    ...
 
 Accessing keys
 --------------
@@ -356,7 +363,7 @@ Accessing keys
 *Groups* and keys in :attr:`job.data` behave similarly to dictionaries.
 To view the keys in a group:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> print(list(job.data.keys()))
     ['x', 'group']
@@ -365,20 +372,21 @@ To view the keys in a group:
 
 To check if keys exist in a group:
 
-.. code-block:: python
+.. code-block:: pycon
 
-    >>> 'subgroup_1' in job.data
+    >>> "subgroup_1" in job.data
     False
-    >>> 'subgroup_1' in job.data.group
+    >>> "subgroup_1" in job.data.group
     True
 
 To iterate through keys in a group (outputs omitted):
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> group = job.data.group
     >>> for key in group:
     ...     group[key][:]
+    ...
 
 
 File handling
@@ -388,19 +396,21 @@ The underlying HDF5 file is opened and flushed after each read- and write-operat
 You can keep the file explicitly open using a context manager.
 The file is only opened and flushed once in the following example:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> with job.data:
-    ...     job.data['hello'] = 'world'
+    ...     job.data["hello"] = "world"
     ...     print(job.data.x)
+    ...
 
 The default open-mode is append (``'a'``), but you can override the open mode by using the :meth:`signac.H5Store.open` function explicitly.
 For example, to open the store in read-only mode, you would write:
 
-.. code-block:: python
+.. code-block:: pycon
 
-    >>> with job.data.open(mode='r'):
+    >>> with job.data.open(mode="r"):
     ...     print(job.data.x)
+    ...
 
 Explicitly opening the underlying file by either using the context manager or the ``open()`` function is required when reading and writing arrays, such as NumPy arrays.
 Please see the :ref:`accessing arrays <accessing-arrays>` section for details on accessing arrays.
@@ -434,10 +444,11 @@ However, in some cases it may be desirable to use more *advanced* functions prov
 The low-level API is exposed as the :attr:`~signac.H5Store.file` property, which is accessible whenever the store is open.
 For example, this is how we could use that to explicitly create an array:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> with job.data:
-    ...     dset = job.data.file.create_dataset("X", (64, 32), dtype='f4')
+    ...     dset = job.data.file.create_dataset("X", (64, 32), dtype="f4")
+    ...
 
 .. note::
 
@@ -465,10 +476,11 @@ In fact, the :attr:`Job.data` container is essentially just an alias for ``job.s
 
 For example, to store an array `X` within a file called ``my_data.h5``, one could use the following approach:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> with job.stores.my_data as data:
-    ...     data['X'] = X
+    ...     data["X"] = X
+    ...
 
 
 The :attr:`Job.stores` attribute is an instance of :class:`signac.H5StoreManager` and implements a dict-like interface.

--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -45,9 +45,9 @@ For example, to initialize a **signac** project named *MyProject* in a directory
 
 You can alternatively initialize your project within Python with the :py:func:`~signac.init_project` function:
 
-.. code-block:: python
+.. code-block:: pycon
 
-    >>> project = signac.init_project('MyProject')
+    >>> project = signac.init_project("MyProject")
 
 This will create a configuration file which contains the name of the project.
 The directory that contains this configuration file is the project's root directory.
@@ -70,7 +70,7 @@ You can access your signac :py:class:`~signac.Project` and the associated *data 
 
 Or with the :py:func:`~signac.get_project` function:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> import signac
     >>> project = signac.get_project()
@@ -100,10 +100,10 @@ For example, to store data associated with particular temperature or pressure of
 
 .. code-block:: python
 
-    project = get_project('path/to/my_project')
-    job = project.open_job({'temperature': 20, 'pressure': 1.0})
+    project = get_project("path/to/my_project")
+    job = project.open_job({"temperature": 20, "pressure": 1.0})
     job.init()
-    with open(job.fn('results.txt')) as file:
+    with open(job.fn("results.txt")) as file:
         ...
 
 .. tip::
@@ -113,7 +113,7 @@ For example, to store data associated with particular temperature or pressure of
 
     .. code-block:: python
 
-        job = project.open_job({'temperature': 20, 'pressure': 1.0}).init()
+        job = project.open_job({"temperature": 20, "pressure": 1.0}).init()
 
 The job *state point* represents a **unique address** of your data within one project.
 There can never be two jobs that share the same *state point* within the same project.
@@ -126,7 +126,7 @@ Any other kind of data and metadata that describe your job, but do not represent
 In addition to obtaining a job handle via the project ``open_job()`` function, you can also access it directly with the :func:`signac.get_job` function.
 For example, you can get a handle on a job by switching into the workspace directory and then calling :func:`signac.get_job`:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> import signac
     >>> job = signac.get_job()
@@ -159,7 +159,7 @@ For example, to iterate over all jobs that have a *state point* parameter ``b=0`
 
 .. code-block:: python
 
-    for job in project.find_jobs({'b': 0}):
+    for job in project.find_jobs({"b": 0}):
         pass
 
 For more information on how to search for specific jobs in Python and on the command line, please see the :ref:`query` chapter.
@@ -188,14 +188,14 @@ If *a* was a state point variable in a project's parameter space, we can quickly
 
 .. code-block:: python
 
-    for a, group in project.groupby('a'):
+    for a, group in project.groupby("a"):
         print(a, list(group))
 
 Similarly, we can group by values in the job document as well. Here, we group all jobs in the project by a job document key *b*:
 
 .. code-block:: python
 
-    for b, group in project.groupbydoc('b'):
+    for b, group in project.groupbydoc("b"):
         print(b, list(group))
 
 
@@ -207,7 +207,7 @@ For example, we can group jobs by state point parameters *c* and *d*:
 
 .. code-block:: python
 
-    for (c, d), group in project.groupby(('c', 'd')):
+    for (c, d), group in project.groupby(("c", "d")):
         print(c, d, list(group))
 
 
@@ -219,7 +219,7 @@ As an example, we can first select all jobs, where the state point key *e* is eq
 
 .. code-block:: python
 
-    for f, group in project.find_jobs({'e': 1}).groupby('f'):
+    for f, group in project.find_jobs({"e": 1}).groupby("f"):
         print(f, list(group))
 
 
@@ -232,7 +232,9 @@ Here is an example using an anonymous *lambda* function as the grouping function
 
 .. code-block:: python
 
-    for (d, count), group in project.groupby(lambda job: (job.sp['d'], job.document['count'])):
+    for (d, count), group in project.groupby(
+        lambda job: (job.sp["d"], job.document["count"])
+    ):
         print(d, count, list(group))
 
 
@@ -246,7 +248,7 @@ To **move** a job to a different project, use the :py:meth:`~signac.contrib.job.
 
 .. code-block:: python
 
-    other_project = get_project(root='/path/to/other_project')
+    other_project = get_project(root="/path/to/other_project")
 
     for job in jobs_to_move:
         job.move(other_project)
@@ -285,11 +287,11 @@ To support the centralization of project-level data, **signac** offers simple fa
 For one, **signac** provides a *project document* and *project data* analogous to the :ref:`job document <project-job-document>` and :ref:`job data <project-job-data>`.
 The project document is stored in JSON format in the project root directory and can be used to store similar types of data to the job document.
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> project = signac.get_project()
-    >>> project.doc['hello'] = 'world'
-    >>> print(project.doc().get('hello'))
+    >>> project.doc["hello"] = "world"
+    >>> print(project.doc().get("hello"))
     'world'
     >>> print(project.doc.hello)
     'world'
@@ -297,43 +299,46 @@ The project document is stored in JSON format in the project root directory and 
 The project data is stored in HDF5 format in a file named ``signac_data.h5`` in the project root directory.
 Although it can be used to store similar types of data as the job document, it is meant for storage of large, array-like or dictionary-like information.
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> project = signac.get_project()
-    >>> project.data['x'] = np.ones([10, 3, 4])
+    >>> project.data["x"] = np.ones([10, 3, 4])
 
 Data may be accessed as an attribute, key, or through a functional interface:
 
 To access data as an attribute:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> with project.data:
     ...     x = project.data.x[:]
+    ...
 
 To access data as a key:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> with project.data:
-    ...     x = project.data['x'][:]
+    ...     x = project.data["x"][:]
+    ...
 
 To access data through a functional interface:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> with project.data:
-    ...     x = project.data.get('x')[:]
+    ...     x = project.data.get("x")[:]
+    ...
 
 .. currentmodule:: signac.contrib.job
 
 In addition, **signac** also provides the :py:meth:`signac.Project.fn` method, which is analogous to the :py:meth:`Job.fn` method described above:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> print(project.root_directory())
     '/home/johndoe/my_project/'
-    >>> print(project.fn('foo.bar'))
+    >>> print(project.fn("foo.bar"))
     '/home/johndoe/my_project/foo.bar'
 
 
@@ -371,12 +376,12 @@ Assuming that we initialize our data space with two state point keys, ``a`` and 
 
     for a in range(3):
         for b in (True, False):
-            project.open_job({'a': a, 'b': b}).init()
+            project.open_job({"a": a, "b": b}).init()
 
 
 Then we can use the :py:meth:`~signac.Project.detect_schema` method to get a basic summary of keys within the project's data space and their respective range:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> print(project.detect_schema())
     {
@@ -527,4 +532,4 @@ Projects can also be synchronized using the Python API:
 
 .. code-block:: python
 
-    project.sync('/remote/my_project')
+    project.sync("/remote/my_project")

--- a/docs/source/query.rst
+++ b/docs/source/query.rst
@@ -30,14 +30,14 @@ For example, in order to select all jobs whose state point key *a* has the value
 
 .. code-block:: python
 
-    project.find_jobs({'sp.a': 'foo', 'doc.b': 'bar'})
+    project.find_jobs({"sp.a": "foo", "doc.b": "bar"})
 
 The default prefix is **sp**, so any filter key that does not have a recognized prefix will be matched against job state points.
 This means that the following query is equivalent to the one above:
 
 .. code-block:: python
 
-    project.find_jobs({'a': 'foo', 'doc.b': 'bar'})
+    project.find_jobs({"a": "foo", "doc.b": "bar"})
 
 For backwards compatibility, some methods in **signac** such as :py:meth:`~signac.Project.find_jobs()` accept separate ``filter`` and ``doc_filter`` arguments, where keys in the ``doc_filter`` are implicitly prefixed with ``'doc.'`` (and state point prefixes in ``filter`` are implicit).
 However, any combination of ``filter`` and ``doc_filter`` without prefixes can be represented by an appropriately namespaced ``filter``, and the unified approach with prefixes should be preferred.
@@ -54,7 +54,7 @@ For example, in order to select all jobs whose state point key *a* has the value
 
 .. code-block:: python
 
-    project.find_jobs({'a': 42})
+    project.find_jobs({"a": 42})
 
 Select All
 ----------
@@ -81,9 +81,9 @@ For example, assuming that we have a list of documents with values *N*, *kT*, an
 
 .. code-block:: python
 
-    1: {'N': 1000, 'kT': 1.0, 'p': 1}
-    2: {'N': 1000, 'kT': 1.2, 'p': 2}
-    3: {'N': 1000, 'kT': 1.3, 'p': 3}
+    1: {"N": 1000, "kT": 1.0, "p": 1}
+    2: {"N": 1000, "kT": 1.2, "p": 2}
+    3: {"N": 1000, "kT": 1.3, "p": 3}
     ...
 
 We can select the 2nd document with ``{'p': 2}``, but also ``{'N': 1000, 'p': 2}`` or any other matching combination.
@@ -98,9 +98,9 @@ For example, if the documents shown in the example above were all nested like th
 
 .. code-block:: python
 
-    1: {'statepoint': {'N': 1000, 'kT': 1.0, 'p': 1}}
-    2: {'statepoint': {'N': 1000, 'kT': 1.2, 'p': 2}}
-    3: {'statepoint': {'N': 1000, 'kT': 1.3, 'p': 3}}
+    1: {"statepoint": {"N": 1000, "kT": 1.0, "p": 1}}
+    2: {"statepoint": {"N": 1000, "kT": 1.2, "p": 2}}
+    3: {"statepoint": {"N": 1000, "kT": 1.3, "p": 3}}
     ...
 
 Then we would use ``{'statepoint.p': 2}`` instead of ``{'statepoint': {'p': 2}}`` as filter argument.
@@ -120,7 +120,7 @@ If we wanted to match all documents where *p is greater than 2*, we would use th
 
 .. code-block:: python
 
-    {'p': {'$gt': 2}}
+    {"p": {"$gt": 2}}
 
 Note that we have replaced the value for p with the expression ``{'$gt': 2}`` to select *all all jobs withe p values greater than 2*.
 Here is a complete list of all available **arithmetic operators**:
@@ -155,17 +155,12 @@ Logical Operators
 There are three supported logical operators: ``$and``, ``$or``, and ``$not``.
 The first two are unique in that they involve combinations of other query operators.
 To query with one of these two logical expression, we construct a mapping with the logical operator as the key and a list of expressions as the value.
-As usual, the ``$and`` operator matches documents where all the expressions are true, while the ``$or`` expression matches if any documents satisfy the provided expression.
-For example, we can match all documents where *p is greater than 2* **or** *kT=1.0* we could use the following (split onto multiple lines for clarity):
+As usual, the ``$and`` operator matches documents where all the expressions are true, while the ``$or`` expression matches if documents satisfy any of the provided expressions.
+For example, to find all documents where *p is greater than 2* **or** *kT=1.0*, we could use the following:
 
 .. code-block:: python
 
-    {
-        '$or': [
-                   {'p': {'$gt': 2}},    # either match this
-                   {'kT': 1.0}           # or this
-               ]
-    }
+    {"$or": [{"p": {"$gt": 2}}, {"kT": 1.0}]}
 
 Logical expressions may be nested, but cannot be the *value* of a key-value expression.
 
@@ -174,9 +169,7 @@ For example, to find all jobs where a parameter *a* is not close to zero, we cou
 
 .. code-block:: python
 
-    {
-        '$not': {'a': {'$near': 0}}
-    }
+    {"$not": {"a": {"$near": 0}}}
 
 .. _exists-operator:
 
@@ -196,7 +189,7 @@ This operator may be used to determine whether specific keys have values, that a
 
 .. code-block:: python
 
-    {'p': {'$in': [1, 2, 3]}}
+    {"p": {"$in": [1, 2, 3]}}
 
 This would return all documents where the value for *p* is either 1, 2, or 3.
 The usage of ``$nin`` is equivalent, and will return all documents where the value is *not in* the given array.
@@ -211,7 +204,7 @@ For example, to match all documents where the value for *protocol* contains the 
 
 .. code-block:: python
 
-    {'protocol': {'$regex': 'assembly'}}
+    {"protocol": {"$regex": "assembly"}}
 
 This operator internally applies the :py:func:`re.search` function and will never match if the value is not of type ``str``.
 
@@ -220,7 +213,7 @@ you would use:
 
 .. code-block:: python
 
-   {'protocol': {'$regex': r'^(?!.*assembly).*$'}}
+   {"protocol": {"$regex": r"^(?!.*assembly).*$"}}
 
 .. _negative lookaround: https://www.regular-expressions.info/lookaround.html
 
@@ -238,7 +231,7 @@ For example, to match all documents, where the value of the key *N* is of intege
 
 .. code-block:: python
 
-    {'N': {'$type': 'int'}}
+    {"N": {"$type": "int"}}
 
 Other supported types include *float*, *str*, *bool*, *list*, and *null*.
 
@@ -252,7 +245,7 @@ For example, instead of using the regex-operator, as shown above, we could write
 
 .. code-block:: python
 
-    {'protocol': {'$where': 'lambda x: "assembly" in x'}}
+    {"protocol": {"$where": 'lambda x: "assembly" in x'}}
 
 
 .. _simplified-filter:

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -43,6 +43,7 @@ You can then implement a simple *data space operation* using **signac-flow** wit
     # project.py
     from flow import FlowProject
 
+
     @FlowProject.operation
     def hello_job(job):
         print(f"Hello from job {job.id}, my foo is {job.sp.foo}.")

--- a/docs/source/recipes.rst
+++ b/docs/source/recipes.rst
@@ -26,11 +26,11 @@ For example, in the tutorial we are modeling a gas using the ideal gas law, but 
 
 Since the ideal gas law can be considered a special case of the equation above with :math:`a=b=0`, we could migrate all jobs with:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> for job in project:
-    ...     job.sp.setdefault('a', 0)
-    ...     job.sp.setdefault('b', 0)
+    ...     job.sp.setdefault("a", 0)
+    ...     job.sp.setdefault("b", 0)
     ...
 
 The ``setdefault()`` function sets the value for :math:`a` and :math:`b` to 0 in case that they are not already present.
@@ -52,9 +52,9 @@ If you want to initialize your workspace with multiple instances of the same sta
 .. code-block:: python
 
     num_reps = 3
-    for i in range(num_reps) :
+    for i in range(num_reps):
         for p in range(1, 11):
-            sp = {'p': p, 'kT': 1.0, 'N': 1000, "replica_index": i}
+            sp = {"p": p, "kT": 1.0, "N": 1000, "replica_index": i}
             job = project.open_job(sp)
             job.init()
 
@@ -72,9 +72,10 @@ Here is an example on how we could recursively replace all dot (.)-characters wi
 
     def migrate(doc):
         if isinstance(doc, Mapping):
-            return {k.replace('.', '_'): migrate(v) for k, v in doc.items()}
+            return {k.replace(".", "_"): migrate(v) for k, v in doc.items()}
         else:
             return doc
+
 
     for job in signac.get_project():
         job.sp = migrate(job.sp)
@@ -94,16 +95,16 @@ We often require multiple jobs with the same state point to collect enough infor
     # init.py
     import signac
 
-    project = signac.init_project('ideal-gas-project')
+    project = signac.init_project("ideal-gas-project")
     num_reps = 3
 
     jobs = project.find_jobs({"replica_index.$exists": False})
     for job in jobs:
-        job.sp['replica_index'] = 0
+        job.sp["replica_index"] = 0
 
     for i in range(num_reps):
         for p in range(1, 11):
-            sp = {'p': p, 'kT': 1.0, 'N': 1000, "replica_index": i}
+            sp = {"p": p, "kT": 1.0, "N": 1000, "replica_index": i}
             project.open_job(sp).init()
 
 Defining a grid of state point values
@@ -117,7 +118,8 @@ Many signac data spaces are structured like a "grid" where the goal is an exhaus
     import itertools
     import signac
 
-    project = signac.init_project('ideal-gas-project')
+    project = signac.init_project("ideal-gas-project")
+
 
     def grid(gridspec):
         """Yields the Cartesian product of a `dict` of iterables.
@@ -131,14 +133,11 @@ Many signac data spaces are structured like a "grid" where the goal is an exhaus
         for values in itertools.product(*gridspec.values()):
             yield dict(zip(gridspec.keys(), values))
 
-    statepoint_grid = {
-        'p': range(1, 11),
-        'kT': [1.0, 5.0, 10.0],
-        'N': [1000, 4000]
-    }
+
+    statepoint_grid = {"p": range(1, 11), "kT": [1.0, 5.0, 10.0], "N": [1000, 4000]}
 
     for sp in grid(statepoint_grid):
-        print('Initializing job', sp)
+        print("Initializing job", sp)
         project.open_job(sp).init()
 
 Creating parameter-dependent operations
@@ -160,13 +159,14 @@ Assuming that we have an operation called *foo*, which depends on parameter *bar
     def setup_foo_workflow(bar):
 
         # Make sure to make the operation-name a function of the parameter(s)!
-        @Project.operation(f'foo-{bar}')
-        @Project.post(lambda job: bar in job.doc.get('foo', []))
+        @Project.operation(f"foo-{bar}")
+        @Project.post(lambda job: bar in job.doc.get("foo", []))
         def foo(job):
-            job.doc.setdefault('foo', []).append(bar)
+            job.doc.setdefault("foo", []).append(bar)
+
 
     for bar in (4, 8, 15, 16, 23, 42):
-       setup_foo_workflow(bar=bar)
+        setup_foo_workflow(bar=bar)
 
 
 .. _rec_external:
@@ -221,6 +221,7 @@ Assuming that your operation is using `mpi4py`_ or similar, you do not have to c
     @FlowProject.operation
     def hello_mpi(job):
         from mpi4py import MPI
+
         print("Hello from rank", MPI.COMM_WORLD.Get_rank())
 
 You could run this operation directly with: ``mpiexec -n 2 python project.py run -o hello_mpi``.
@@ -238,10 +239,11 @@ You could run this operation directly with: ``mpiexec -n 2 python project.py run
     .. code-block:: python
 
         from mpi4py import MPI
+
         comm = MPI.COMM_WORLD
 
         if comm.Get_rank() == 0:
-            job.doc.foo = 'abc'
+            job.doc.foo = "abc"
         comm.barrier()
 
 
@@ -302,11 +304,13 @@ For example:
 
     # [...]
 
+
     @Project.operation
     @Project.pre.after(bar)
     @Project.post.isfile("foo.txt")
     @Project.post.never  # TODO: Remove after debugging
     def foo(job):
+        pass
         # ...
 
 Then you could execute the operation for a hypothetical job with id *abc123*, for example with ``$ python project.py run -o foo -j abc123``, irrespective of whether the ``foo.txt`` file exists or not.
@@ -348,7 +352,7 @@ If you are using the ``run`` command for execution, simply execute the whole scr
     .. code-block:: python
 
         def on_container(func):
-            return flow.directives(executable='singularity exec software.simg python')(func)
+            return flow.directives(executable="singularity exec software.simg python")(func)
 
 
         @on_container
@@ -387,30 +391,39 @@ different environment.
     # project.py
     from flow import FlowProject, directives
 
+
     class Project(FlowProject):
         pass
 
-    supercomputer = Project.make_group(name='supercomputer')
-    laptop = Project.make_group(name='laptop')
-    desktop = Project.make_group(name='desktop')
 
-    @supercomputer.with_directives(directives=dict(
-        ngpu=4, executable="singularity exec --nv /path/to/container python"))
+    supercomputer = Project.make_group(name="supercomputer")
+    laptop = Project.make_group(name="laptop")
+    desktop = Project.make_group(name="desktop")
+
+
+    @supercomputer.with_directives(
+        directives=dict(
+            ngpu=4, executable="singularity exec --nv /path/to/container python"
+        )
+    )
     @laptop.with_directives(directives=dict(ngpu=0))
     @desktop.with_directives(directives=dict(ngpu=1))
     @Project.operation
     def op1(job):
         pass
 
-    @supercomputer.with_directives(directives=dict(
-        nranks=40, executable="singularity exec /path/to/container python"))
+
+    @supercomputer.with_directives(
+        directives=dict(nranks=40, executable="singularity exec /path/to/container python")
+    )
     @laptop.with_directives(directives=dict(nranks=4))
     @desktop.with_directives(directives=dict(nranks=8))
     @Project.operation
     def op2(job):
         pass
 
-    if __name__ == '__main__':
+
+    if __name__ == "__main__":
         Project().main()
 
 

--- a/docs/source/tips_and_tricks.rst
+++ b/docs/source/tips_and_tricks.rst
@@ -42,13 +42,13 @@ For example, extracting the volume from a particular job originally consisted of
 
 .. code-block:: python
 
-    volume = float(open(job.fn('volume.txt')).read())
+    volume = float(open(job.fn("volume.txt")).read())
 
 Now, we instead need to adjust the filename for each job:
 
 .. code-block:: python
 
-    volume = float(open(job.fn('volume_pressure_{}.txt'.format(job.sp.p))).read())
+    volume = float(open(job.fn("volume_pressure_{}.txt".format(job.sp.p))).read())
 
 In general, it is desirable to keep the filenames across the workspace as uniform as possible.
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -44,10 +44,10 @@ We then proceed by initializing the data space within a Python script called ``i
     # init.py
     import signac
 
-    project = signac.init_project('ideal-gas-project')
+    project = signac.init_project("ideal-gas-project")
 
     for p in range(1, 10):
-        sp = {'p': p, 'kT': 1.0, 'N': 1000}
+        sp = {"p": p, "kT": 1.0, "N": 1000}
         job = project.open_job(sp)
         job.init()
 
@@ -123,7 +123,7 @@ You interact with the **signac** project on the command line using the ``signac`
 You can also interact with the project within Python *via* the :py:class:`signac.Project` class.
 You can obtain an instance of that class within the project root directory and all sub-directories with:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> import signac
     >>> project = signac.get_project()
@@ -137,7 +137,7 @@ You can obtain an instance of that class within the project root directory and a
 
 Iterating through all jobs within the data space is then as easy as:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> for job in project:
     ...     print(job)
@@ -149,7 +149,7 @@ Iterating through all jobs within the data space is then as easy as:
 
 We can iterate through a select set of jobs with the :py:meth:`~signac.Project.find_jobs` method in combination with a query expression:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> for job in project.find_jobs({"kT": 1.0, "p.$lt": 3.0}):
     ...     print(job, job.sp.p)
@@ -190,8 +190,9 @@ Let's store the volume within our data space in a file called ``volume.txt``, by
 
     def compute_volume(job):
         volume = job.sp.N * job.sp.kT / job.sp.p
-        with open(job.fn('volume.txt'), 'w') as file:
-            file.write(str(volume) + '\n')
+        with open(job.fn("volume.txt"), "w") as file:
+            file.write(str(volume) + "\n")
+
 
     project = signac.get_project()
     for job in project:
@@ -224,11 +225,11 @@ We slightly modify our ``project.py`` script:
     @FlowProject.operation
     def compute_volume(job):
         volume = job.sp.N * job.sp.kT / job.sp.p
-        with open(job.fn('volume.txt'), 'w') as file:
-            file.write(str(volume) + '\n')
+        with open(job.fn("volume.txt"), "w") as file:
+            file.write(str(volume) + "\n")
 
 
-    if __name__ == '__main__':
+    if __name__ == "__main__":
         FlowProject().main()
 
 The :py:meth:`~.flow.FlowProject.operation` decorator identifies the ``compute_volume`` function as an *operation function* of our project.
@@ -268,11 +269,11 @@ To tell the :py:class:`~.flow.FlowProject` class when an operation is *completed
     @FlowProject.post(volume_computed)
     def compute_volume(job):
         volume = job.sp.N * job.sp.kT / job.sp.p
-        with open(job.fn('volume.txt'), 'w') as file:
-            file.write(str(volume) + '\n')
+        with open(job.fn("volume.txt"), "w") as file:
+            file.write(str(volume) + "\n")
 
 
-    if __name__ == '__main__':
+    if __name__ == "__main__":
         FlowProject().main()
 
 .. tip::
@@ -308,6 +309,7 @@ For this we transform the ``volume_computed()`` function into a *label function*
     def volume_computed(job):
         return job.isfile("volume.txt")
 
+
     # ...
 
 We can then view the project's status with the ``status`` command:
@@ -336,7 +338,9 @@ Since we are pretending that computing the volume is an expensive operation, we 
     # project.py
     from flow import FlowProject
     import json
+
     # ...
+
 
     @FlowProject.operation
     @FlowProject.pre(volume_computed)
@@ -346,6 +350,7 @@ Since we are pretending that computing the volume is an expensive operation, we 
             data = {"volume": float(textfile.read())}
             with open(job.fn("data.json"), "w") as jsonfile:
                 json.dump(data, jsonfile)
+
 
     # ...
 
@@ -392,19 +397,22 @@ with it.
     from flow import FlowProject
     import json
 
-    volume_group = FlowProject.make_group(name='volume')
+    volume_group = FlowProject.make_group(name="volume")
+
 
     @FlowProject.label
     def volume_computed(job):
         return job.isfile("volume.txt")
+
 
     @volume_group
     @FlowProject.operation
     @FlowProject.post(volume_computed)
     def compute_volume(job):
         volume = job.sp.N * job.sp.kT / job.sp.p
-        with open(job.fn('volume.txt'), 'w') as file:
-            file.write(str(volume) + '\n')
+        with open(job.fn("volume.txt"), "w") as file:
+            file.write(str(volume) + "\n")
+
 
     @volume_group
     @FlowProject.operation
@@ -416,7 +424,8 @@ with it.
             with open(job.fn("data.json"), "w") as jsonfile:
                 json.dump(data, jsonfile)
 
-    if __name__ == '__main__':
+
+    if __name__ == "__main__":
         FlowProject().main()
 
 We can now run :code:`python project.py run -o volume` or
@@ -435,9 +444,10 @@ Let's add another operation to our ``project.py`` script that stores the volume 
      # project.py
      # ...
 
+
      @FlowProject.operation
      @FlowProject.pre.after(compute_volume)
-     @FlowProject.post(lambda job: 'volume' in job.document)
+     @FlowProject.post(lambda job: "volume" in job.document)
      def store_volume_in_document(job):
          with open(job.fn("volume.txt")) as textfile:
              job.document.volume = float(textfile.read())


### PR DESCRIPTION
## Description
This PR adds a pre-commit hook for [blacken-docs](https://github.com/asottile/blacken-docs).

## Motivation and Context
I like the idea of enforcing code style in our documentation, especially because long lines render poorly in the online documentation. The line wrapping enforced by `black` will prevent such long lines that would create a scrollbar in the code snippet.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-docs/blob/master/ContributorAgreement.md).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md#code-style) of this project.
