### PR TITLE
Update tutorial.rst

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -477,8 +477,8 @@ In addition to selecting by metadata as shown earlier, we can also find and sele
 
 .. code-block:: bash
 
-    ~/ideal_gas_project $ signac find --doc-filter volume.\$lte 125 --show
-    Interpreted filter arguments as '{"volume.$lte": 125}'.
+    ~/ideal_gas_project $ signac find doc.volume.\$lte 125 --show
+    Interpreted filter arguments as '{"doc.volume.$lte": 125}'.
     df1794892c1ec0909e5955079754fb0b
     {'N': 1000, 'kT': 1.0, 'p': 10}
     {'volume': 100.0}


### PR DESCRIPTION
I was following the tutorial and I got the message that the --doc-filter option is deprecated from version 1.7.0. I think that the tutorial should be changed to reflect the new filter syntax :)

<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-docs/blob/master/ContributorAgreement.md).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md#code-style) of this project.
