### PR TITLE
Add how to on debugging containered operations.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,7 +71,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/source/recipes.rst
+++ b/docs/source/recipes.rst
@@ -437,3 +437,37 @@ different environment.
 
    To test operations with a small interactive job, a 'test' group can be used
    to ensure that the operations do not try to run on multiple cores or GPUs.
+
+Pass options to operations run through containers or another environment
+========================================================================
+
+When executing an operation in a container (e.g. Singularity or Docker) or a different environment
+``FlowGroups`` can be used to passed options to an ``exec`` command. Below is an example which shows
+how to use this feature to get debug information from an operation executed in a container.
+
+.. code-block:: python
+
+    # project.py
+    from flow import FlowProject
+
+    class Project(flow.FlowProject):
+        pass
+
+
+    debug = Project.make_group("debug", run_options="--debug")
+
+    # Other decorators can be applied like normal.
+    @Project.post.isfile("a.txt")
+    # Must be first decorator.
+    @debug
+    @Project.operation.with_directives({"executable": "/path/to/container exec python3"})
+    def op1(job):
+        with open(job.fn("a.txt"), "w") as fh:
+            fh.write("hello world")
+
+
+    if __name__ == "__main__":
+        Project().main()
+
+
+To run the operation with debugging, use ``python3 project.py run -o debug``.

--- a/docs/source/recipes.rst
+++ b/docs/source/recipes.rst
@@ -438,12 +438,12 @@ different environment.
    To test operations with a small interactive job, a 'test' group can be used
    to ensure that the operations do not try to run on multiple cores or GPUs.
 
-Pass options to operations run through containers or another environment
+Passing command line options to operations run in a container or other environment
 ========================================================================
 
-When executing an operation in a container (e.g. Singularity or Docker) or a different environment
-``FlowGroups`` can be used to passed options to an ``exec`` command. Below is an example which shows
-how to use this feature to get debug information from an operation executed in a container.
+When executing an operation in a container (e.g. Singularity or Docker) or a different environment, the operation will not receive command line flags from the submitting process.
+``FlowGroups`` can be used to pass options to an ``exec`` command. This example shows
+how to use the `run_options` argument to tell an operation executed in a container to run in debug mode.
 
 .. code-block:: python
 
@@ -471,4 +471,4 @@ how to use this feature to get debug information from an operation executed in a
         Project().main()
 
 
-To run the operation with debugging, use ``python3 project.py run -o debug``.
+To run the operation with debugging, run the group called "debug" with ``python3 project.py run -o debug``.

--- a/docs/source/recipes.rst
+++ b/docs/source/recipes.rst
@@ -439,11 +439,12 @@ different environment.
    to ensure that the operations do not try to run on multiple cores or GPUs.
 
 Passing command line options to operations run in a container or other environment
-========================================================================
+==================================================================================
 
-When executing an operation in a container (e.g. Singularity or Docker) or a different environment, the operation will not receive command line flags from the submitting process.
-``FlowGroups`` can be used to pass options to an ``exec`` command. This example shows
-how to use the `run_options` argument to tell an operation executed in a container to run in debug mode.
+When executing an operation in a container (e.g. Singularity or Docker) or a different environment,
+the operation will not receive command line flags from the submitting process. ``FlowGroups`` can be
+used to pass options to an ``exec`` command. This example shows how to use the `run_options`
+argument to tell an operation executed in a container to run in debug mode.
 
 .. code-block:: python
 
@@ -455,12 +456,13 @@ how to use the `run_options` argument to tell an operation executed in a contain
         pass
 
 
+    # Anything in run_options will be passed to the forked exec command when the operation is run.
+    # Here we just pass the debug flag.
     debug = Project.make_group("debug", run_options="--debug")
 
-    # Other decorators can be applied like normal.
-    @Project.post.isfile("a.txt")
-    # Must be first decorator.
+
     @debug
+    @Project.post.isfile("a.txt")
     @Project.operation.with_directives({"executable": "/path/to/container exec python3"})
     def op1(job):
         with open(job.fn("a.txt"), "w") as fh:
@@ -471,4 +473,5 @@ how to use the `run_options` argument to tell an operation executed in a contain
         Project().main()
 
 
-To run the operation with debugging, run the group called "debug" with ``python3 project.py run -o debug``.
+To run the operation with debugging, run the group called "debug" with ``python3 project.py run -o
+debug``.

--- a/docs/source/recipes.rst
+++ b/docs/source/recipes.rst
@@ -450,6 +450,7 @@ how to use this feature to get debug information from an operation executed in a
     # project.py
     from flow import FlowProject
 
+
     class Project(flow.FlowProject):
         pass
 


### PR DESCRIPTION

## Description
Adds a how-to on debugging operations that are run within a container or a different environment than the operation is submitted or run on.

## Motivation and Context
This is actually somewhat difficult to solve. I had added a `post_command` directive on local `signac-flow` branches to achieve this, but it is possible to do without having to modify `flow` hence the PR.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-docs/blob/master/ContributorAgreement.md).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md#code-style) of this project.
