### PR TITLE
Migrate setup.py references to pyproject.toml.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ All contributors must agree to the Contributor Agreement ([ContributorAgreement.
   * Use the [OneFlow](https://www.endoflineblog.com/oneflow-a-git-branching-model-and-workflow) model of development:
     - Both new features and bug fixes should be developed in branches based on `master`.
     - Hotfixes (critical bugs that need to be released *fast*) should be developed in a branch based on the latest tagged release.
-  * Write code that is compatible with all supported versions of Python (listed in [setup.py](https://github.com/glotzerlab/signac/blob/master/setup.py)).
+  * Write code that is compatible with all supported versions of Python (listed in [pyproject.toml](https://github.com/glotzerlab/signac/blob/master/pyproject.toml)).
   * Avoid introducing dependencies -- especially those that might be harder to install in high-performance computing environments.
   * Create [unit tests](https://en.wikipedia.org/wiki/Unit_testing) and [integration tests](https://en.wikipedia.org/wiki/Integration_testing) that cover the common cases and the corner cases of the code.
   * Preserve backwards-compatibility whenever possible, and make clear if something must change.

--- a/docs/source/community.rst
+++ b/docs/source/community.rst
@@ -60,7 +60,7 @@ All code contributed via pull request needs to adhere to the following guideline
     - Both new features and bug fixes should be developed in branches based on ``master``.
     - Hotfixes (critical bugs that need to be released *fast*) should be developed in a branch based on the latest tagged release.
 
-  * Write code that is compatible with all supported versions of Python (listed in the package ``setup.py`` file).
+  * Write code that is compatible with all supported versions of Python (listed in the package ``pyproject.toml`` file).
   * Avoid introducing dependencies -- especially those that might be harder to install in high-performance computing environments.
   * All code needs to adhere to the PEP8_ style guide, with the exception that a line may have up to 100 characters.
   * Create `unit tests <https://en.wikipedia.org/wiki/Unit_testing>`_  and `integration tests <ttps://en.wikipedia.org/wiki/Integration_testing>`_ that cover the common cases and the corner cases of the code.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -47,18 +47,18 @@ For a standard installation with pip_, execute:
 Installation from Source
 ========================
 
-Alternatively, you can clone any of the package's source code repositories and install them manually.
+Alternatively, you can clone any of the packages' source code repositories and install them manually.
 For example, to install the signac core package you can execute the following code:
 
 .. code:: bash
 
+  # Option 1
   git clone https://github.com/glotzerlab/signac.git
   cd signac
-  python setup.py install --user
+  pip install .
 
-.. note::
-
-    If you want to install packages for all users on a machine, you can remove the ``--user`` option in the install command.
+  # Option 2
+  pip install git+https://github.com/glotzerlab/signac.git
 
 
 Build Status


### PR DESCRIPTION
## Description
Fixes outdated references to setup.py in the docs.

Aligns with https://github.com/glotzerlab/signac/pull/878, https://github.com/glotzerlab/signac-flow/pull/704.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-docs/blob/master/ContributorAgreement.md).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md#code-style) of this project.
