### PR TITLE
Remove Zenodo reference.

### DIFF
--- a/docs/source/acknowledge.bib
+++ b/docs/source/acknowledge.bib
@@ -31,14 +31,3 @@
   pages = {23--32},
   doi = {10.25080/majora-1b6fd038-003}
 }
-@misc{signac_zenodo,
-  title = {glotzerlab/signac},
-  author = {
-    Carl S. Adorf and Vyas Ramasubramani and Bradley D. Dice and Michael M. Henry and
-    Paul M. Dodd and Sharon C. Glotzer
-  },
-  year = 2019,
-  month = feb,
-  doi = {10.5281/zenodo.2581327},
-  url = {https://doi.org/10.5281/zenodo.2581327}
-}

--- a/docs/source/acknowledge.rst
+++ b/docs/source/acknowledge.rst
@@ -46,15 +46,6 @@ If your paper makes use of the **signac-flow** features for aggregation or group
 
 --------
 
-If possible, we also recommend including a citation of the associated Zenodo resource:
-
-.. bibliography::
-    :filter: False
-
-    signac_zenodo
-
---------
-
 To cite these references, you can use the following BibTeX entries:
 
 


### PR DESCRIPTION
## Description
Companion PR to https://github.com/glotzerlab/signac/pull/903. We haven't been keeping Zenodo up to date (last updated February 2019) and it gets very few citations (only 4 citations listed on the [Zenodo page](https://zenodo.org/record/2581327) and 9 on [Google Scholar](https://scholar.google.com/scholar?cites=16862461478172395566&as_sdt=400005&sciodt=0,14&hl=en), compared to [95 Google Scholar citations of the 2018 paper](https://scholar.google.com/scholar?cites=14270565839129827405&as_sdt=400005&sciodt=0,14&hl=en)). We're going to remove it, to simplify the process of acknowledgement and avoid pointing to outdated content.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-docs/blob/master/ContributorAgreement.md).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-docs/blob/master/CONTRIBUTING.md#code-style) of this project.
