### PR TITLE
Add note about defining custom environments in a separate module

### DIFF
--- a/docs/source/environments.rst
+++ b/docs/source/environments.rst
@@ -43,13 +43,6 @@ Those are the steps usually required to define a new environment:
   2. Determine a `regular expression <https://en.wikipedia.org/wiki/Regular_expression>`_ that would match the output of :py:func:`socket.getfqdn()`.
   3. Create a template and specify the template name as ``template`` class variable.
 
-.. note::
-
-    The custom environment class should be defined in and then imported from a separate Python module file (e.g., `environments.py`) in the project root directory and not in the `project.py` file to avoid an inconsequential warning.
-    Defining it within in the `project.py` module will produce the warning shown below, but the code should still execute as expected.
-
-    "WARNING:flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'"
-
 
 This is an example for a typical environment class definition:
 
@@ -63,7 +56,19 @@ Then, add the ``myuniversity-mycluster.sh`` template script to the ``templates/`
 
 .. important::
 
-    The new environment will be automatically registered and used as long as it is either defined within the same module as your :py:class:`~flow.FlowProject` class or its module is imported into the same module.
+    To avoid an inconsequential warning and automatically register the new environment,  
+    the custom environment class should be defined in and then imported from a separate 
+    Python module file (e.g., `environments.py`), located in the the project root directory 
+    and not in the `project.py` file.  The `project.py` file should import the 
+    Python module file (e.g., `environments.py`) and define the :py:class:`~flow.FlowProject` 
+    class's module.
+    Defining the custom environment class within in the `project.py` module will produce 
+    the warning shown below, but the code should still execute as expected.
+    
+    .. code-block:: python
+    
+    WARNING:flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'
+
 
 As an example on how to write a submission script template, this would be a viable template to define the header for a SLURM scheduler:
 

--- a/docs/source/environments.rst
+++ b/docs/source/environments.rst
@@ -67,7 +67,9 @@ Then, add the ``myuniversity-mycluster.sh`` template script to the ``templates/`
 
 .. code-block:: python
 
-    warning("flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'")
+    warning(
+        "flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'"
+    )
 
 
 As an example on how to write a submission script template, this would be a viable template to define the header for a SLURM scheduler:

--- a/docs/source/environments.rst
+++ b/docs/source/environments.rst
@@ -43,12 +43,24 @@ Those are the steps usually required to define a new environment:
   2. Determine a `regular expression <https://en.wikipedia.org/wiki/Regular_expression>`_ that would match the output of :py:func:`socket.getfqdn()`.
   3. Create a template and specify the template name as ``template`` class variable.
 
+.. note::
+
+    The custom environment class should be defined in and then imported from a separate Python module file (e.g., `environments.py`) in the project root directory and not in the `project.py` file to avoid an inconsequential warning.
+    Defining it within in the `project.py` module will produce the warning shown below, but the code should still execute as expected.
+
+    "WARNING:flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'"
+
+
 This is an example for a typical environment class definition:
 
 .. code-block:: python
 
       class MyUniversityCluster(flow.environment.DefaultSlurmEnvironment):
+          # Find the hostname for the HPC by using the 'hostname' command.
+          # In this case 'hostname' produced 'hpc_node-slurm-2\.hpc_name\.university_name\.edu'.
           hostname_pattern = r".*\.mycluster\.university\.edu$"  # Matches names like login.mycluster.university.edu
+          # The 'template' file contains the custom instructions to the HPC submission script, which
+        # are stored in the 'templates' folder.
           template = "myuniversity-mycluster.sh"
 
 Then, add the ``myuniversity-mycluster.sh`` template script to the ``templates/`` directory within your project root directory.

--- a/docs/source/environments.rst
+++ b/docs/source/environments.rst
@@ -67,7 +67,7 @@ Then, add the ``myuniversity-mycluster.sh`` template script to the ``templates/`
 
 .. code-block:: python
 
-    WARNING:flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'
+    warning("flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'")
 
 
 As an example on how to write a submission script template, this would be a viable template to define the header for a SLURM scheduler:

--- a/docs/source/environments.rst
+++ b/docs/source/environments.rst
@@ -56,17 +56,17 @@ Then, add the ``myuniversity-mycluster.sh`` template script to the ``templates/`
 
 .. important::
 
-    To avoid an inconsequential warning and automatically register the new environment,  
-    the custom environment class should be defined in and then imported from a separate 
-    Python module file (e.g., `environments.py`), located in the the project root directory 
-    and not in the `project.py` file.  The `project.py` file should import the 
-    Python module file (e.g., `environments.py`) and define the :py:class:`~flow.FlowProject` 
+    To avoid an inconsequential warning and automatically register the new environment,
+    the custom environment class should be defined in and then imported from a separate
+    Python module file (e.g., `environments.py`), located in the the project root directory
+    and not in the `project.py` file.  The `project.py` file should import the
+    Python module file (e.g., `environments.py`) and define the :py:class:`~flow.FlowProject`
     class's module.
-    Defining the custom environment class within in the `project.py` module will produce 
+    Defining the custom environment class within in the `project.py` module will produce
     the warning shown below, but the code should still execute as expected.
-    
+
     .. code-block:: python
-    
+
     WARNING:flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'
 
 

--- a/docs/source/environments.rst
+++ b/docs/source/environments.rst
@@ -56,11 +56,7 @@ This is an example for a typical environment class definition:
 .. code-block:: python
 
       class MyUniversityCluster(flow.environment.DefaultSlurmEnvironment):
-          # Find the hostname for the HPC by using the 'hostname' command.
-          # In this case 'hostname' produced 'hpc_node-slurm-2\.hpc_name\.university_name\.edu'.
           hostname_pattern = r".*\.mycluster\.university\.edu$"  # Matches names like login.mycluster.university.edu
-          # The 'template' file contains the custom instructions to the HPC submission script, which
-          # are stored in the 'templates' folder.
           template = "myuniversity-mycluster.sh"
 
 Then, add the ``myuniversity-mycluster.sh`` template script to the ``templates/`` directory within your project root directory.

--- a/docs/source/environments.rst
+++ b/docs/source/environments.rst
@@ -63,7 +63,7 @@ Then, add the ``myuniversity-mycluster.sh`` template script to the ``templates/`
     Python module file (e.g., `environments.py`) and define the :py:class:`~flow.FlowProject`
     class's module.
     Defining the custom environment class within in the `project.py` module will produce
-    the warning, "flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'", 
+    the warning, "flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'",
     but the code should still execute as expected.
 
 

--- a/docs/source/environments.rst
+++ b/docs/source/environments.rst
@@ -63,13 +63,8 @@ Then, add the ``myuniversity-mycluster.sh`` template script to the ``templates/`
     Python module file (e.g., `environments.py`) and define the :py:class:`~flow.FlowProject`
     class's module.
     Defining the custom environment class within in the `project.py` module will produce
-    the warning shown below, but the code should still execute as expected.
-
-.. code-block:: python
-
-    warning(
-        "flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'"
-    )
+    the warning, "flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'", 
+    but the code should still execute as expected.
 
 
 As an example on how to write a submission script template, this would be a viable template to define the header for a SLURM scheduler:

--- a/docs/source/environments.rst
+++ b/docs/source/environments.rst
@@ -60,7 +60,7 @@ This is an example for a typical environment class definition:
           # In this case 'hostname' produced 'hpc_node-slurm-2\.hpc_name\.university_name\.edu'.
           hostname_pattern = r".*\.mycluster\.university\.edu$"  # Matches names like login.mycluster.university.edu
           # The 'template' file contains the custom instructions to the HPC submission script, which
-        # are stored in the 'templates' folder.
+          # are stored in the 'templates' folder.
           template = "myuniversity-mycluster.sh"
 
 Then, add the ``myuniversity-mycluster.sh`` template script to the ``templates/`` directory within your project root directory.

--- a/docs/source/environments.rst
+++ b/docs/source/environments.rst
@@ -65,7 +65,7 @@ Then, add the ``myuniversity-mycluster.sh`` template script to the ``templates/`
     Defining the custom environment class within in the `project.py` module will produce
     the warning shown below, but the code should still execute as expected.
 
-    .. code-block:: python
+.. code-block:: python
 
     WARNING:flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'
 

--- a/docs/source/environments.rst
+++ b/docs/source/environments.rst
@@ -43,7 +43,6 @@ Those are the steps usually required to define a new environment:
   2. Determine a `regular expression <https://en.wikipedia.org/wiki/Regular_expression>`_ that would match the output of :py:func:`socket.getfqdn()`.
   3. Create a template and specify the template name as ``template`` class variable.
 
-
 This is an example for a typical environment class definition:
 
 .. code-block:: python

--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -69,7 +69,7 @@ The third line is the actual command that we want to add and the fourth line ens
         # The 'template' file contains the custom instructions to the HPC submission script, which
         # are stored in the 'templates' folder.
         template = "hpc_name.sh"
-        
+
 .. warning::
 
     WARNING:flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'.

--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -53,6 +53,26 @@ The first line again indicates that this template extends an existing template b
 The second and last line indicate that the enclosed lines are to be placed in the *body* block of the base template.
 The third line is the actual command that we want to add and the fourth line ensures that the code provided by the base template within the body block is still added.
 
+.. note::
+
+    This custom HPC class `class` (see code below) should be stored in its own `python` file (named `hpc_setup.py`) in the main directory and not in the the `project.py` file.  
+    Storing it in the `project.py` file will result in the following warning, but the code should still execute properly.  
+
+.. code-block:: python
+
+    class HPC_name(DefaultSlurmEnvironment):  
+        """Subclass of DefaultSlurmEnvironment for 'hpc_name' HPC."""
+        # Find the hostname by loggin in the HPC and using the 'hostname' command.
+        # In this case 'hostname' produced 'hpc_login_node-slurm-2\.hpc_name\.university_name\.edu'.
+        hostname_pattern = r"hpc_login_node-slurm-.\.hpc_name\.university_name\.edu"
+        # The 'template' file contains the custom instructions to the HPC submission script, which 
+        # are stored in the 'templates' folder.
+        template = "hpc_name.sh"
+
+.. warning::
+
+    WARNING:flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'.
+
 The base template
 =================
 

--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -59,6 +59,7 @@ The third line is the actual command that we want to add and the fourth line ens
     Storing it in the `project.py` file will result in the following warning, but the code should still execute properly.
 
 .. code-block:: python
+
     class HPC_name(DefaultSlurmEnvironment):
         """Subclass of DefaultSlurmEnvironment for 'hpc_name' HPC."""
 
@@ -68,6 +69,7 @@ The third line is the actual command that we want to add and the fourth line ens
         # The 'template' file contains the custom instructions to the HPC submission script, which
         # are stored in the 'templates' folder.
         template = "hpc_name.sh"
+        
 .. warning::
 
     WARNING:flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'.

--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -57,7 +57,6 @@ The third line is the actual command that we want to add and the fourth line ens
 
     This custom HPC `class` (see code below) should be stored in its own `python` file (named `hpc_setup.py`) in the main directory and not in the the `project.py` file.
     Storing it in the `project.py` file will result in the following warning, but the code should still execute properly.
-
     You will also need to `import hpc_setup` in the `project.py` file.
 
 .. code-block:: python

--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -61,6 +61,7 @@ The third line is the actual command that we want to add and the fourth line ens
 .. code-block:: python
     class HPC_name(DefaultSlurmEnvironment):
         """Subclass of DefaultSlurmEnvironment for 'hpc_name' HPC."""
+
         # Find the hostname by loggin in the HPC and using the 'hostname' command.
         # In this case 'hostname' produced 'hpc_loggin_node-slurm-2\.hpc_name\.university_name\.edu'.
         hostname_pattern = r"hpc_loggin_node-slurm-.\.hpc_name\.university_name\.edu"

--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -55,7 +55,7 @@ The third line is the actual command that we want to add and the fourth line ens
 
 .. note::
 
-    This custom HPC class `class` (see code below) should be stored in its own `python` file (named `hpc_setup.py`) in the main directory and not in the the `project.py` file.
+    This custom HPC `class` (see code below) should be stored in its own `python` file (named `hpc_setup.py`) in the main directory and not in the the `project.py` file.
     Storing it in the `project.py` file will result in the following warning, but the code should still execute properly.
 
 .. code-block:: python

--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -59,17 +59,14 @@ The third line is the actual command that we want to add and the fourth line ens
     Storing it in the `project.py` file will result in the following warning, but the code should still execute properly.
 
 .. code-block:: python
-
     class HPC_name(DefaultSlurmEnvironment):
         """Subclass of DefaultSlurmEnvironment for 'hpc_name' HPC."""
-
         # Find the hostname by loggin in the HPC and using the 'hostname' command.
-        # In this case 'hostname' produced 'hpc_login_node-slurm-2\.hpc_name\.university_name\.edu'.
-        hostname_pattern = r"hpc_login_node-slurm-.\.hpc_name\.university_name\.edu"
+        # In this case 'hostname' produced 'hpc_loggin_node-slurm-2\.hpc_name\.university_name\.edu'.
+        hostname_pattern = r"hpc_loggin_node-slurm-.\.hpc_name\.university_name\.edu"
         # The 'template' file contains the custom instructions to the HPC submission script, which
         # are stored in the 'templates' folder.
         template = "hpc_name.sh"
-
 .. warning::
 
     WARNING:flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'.

--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -53,29 +53,6 @@ The first line again indicates that this template extends an existing template b
 The second and last line indicate that the enclosed lines are to be placed in the *body* block of the base template.
 The third line is the actual command that we want to add and the fourth line ensures that the code provided by the base template within the body block is still added.
 
-.. note::
-
-    The custom environment class should be defined in and then imported from a separate Python module file (e.g., `environments.py`) in the project root directory and not in the `project.py` file to avoid an inconsequential warning.
-    Defining it within in the `project.py` module will produce the warning shown below, but the code should still execute as expected.
-
-    "WARNING:flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'"
-
-
-.. code-block:: python
-
-    class HPC_name(DefaultSlurmEnvironment):
-        """Subclass of DefaultSlurmEnvironment for 'hpc_name' HPC."""
-
-        # Find the hostname for the HPC by using the 'hostname' command.
-        # In this case 'hostname' produced 'hpc_node-slurm-2\.hpc_name\.university_name\.edu'.
-        hostname_pattern = r"hpc_node-slurm-.\.hpc_name\.university_name\.edu"
-        # The 'template' file contains the custom instructions to the HPC submission script, which
-        # are stored in the 'templates' folder.
-        template = "hpc_name.sh"
-
-
-
-
 The base template
 =================
 

--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -59,7 +59,7 @@ The third line is the actual command that we want to add and the fourth line ens
     Defining it within in the `project.py` module will produce the warning shown below, but the code should still execute as expected.
 
     "WARNING:flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'"
-    
+
 
 .. code-block:: python
 
@@ -74,7 +74,7 @@ The third line is the actual command that we want to add and the fourth line ens
         template = "hpc_name.sh"
 
 
-    
+
 
 The base template
 =================

--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -55,17 +55,18 @@ The third line is the actual command that we want to add and the fourth line ens
 
 .. note::
 
-    This custom HPC class `class` (see code below) should be stored in its own `python` file (named `hpc_setup.py`) in the main directory and not in the the `project.py` file.  
-    Storing it in the `project.py` file will result in the following warning, but the code should still execute properly.  
+    This custom HPC class `class` (see code below) should be stored in its own `python` file (named `hpc_setup.py`) in the main directory and not in the the `project.py` file.
+    Storing it in the `project.py` file will result in the following warning, but the code should still execute properly.
 
 .. code-block:: python
 
-    class HPC_name(DefaultSlurmEnvironment):  
+    class HPC_name(DefaultSlurmEnvironment):
         """Subclass of DefaultSlurmEnvironment for 'hpc_name' HPC."""
+
         # Find the hostname by loggin in the HPC and using the 'hostname' command.
         # In this case 'hostname' produced 'hpc_login_node-slurm-2\.hpc_name\.university_name\.edu'.
         hostname_pattern = r"hpc_login_node-slurm-.\.hpc_name\.university_name\.edu"
-        # The 'template' file contains the custom instructions to the HPC submission script, which 
+        # The 'template' file contains the custom instructions to the HPC submission script, which
         # are stored in the 'templates' folder.
         template = "hpc_name.sh"
 

--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -62,9 +62,9 @@ The third line is the actual command that we want to add and the fourth line ens
     class HPC_name(DefaultSlurmEnvironment):
         """Subclass of DefaultSlurmEnvironment for 'hpc_name' HPC."""
 
-        # Find the hostname by loggin in the HPC and using the 'hostname' command.
-        # In this case 'hostname' produced 'hpc_loggin_node-slurm-2\.hpc_name\.university_name\.edu'.
-        hostname_pattern = r"hpc_loggin_node-slurm-.\.hpc_name\.university_name\.edu"
+        # Find the hostname for the HPC by using the 'hostname' command.
+        # In this case 'hostname' produced 'hpc_node-slurm-2\.hpc_name\.university_name\.edu'.
+        hostname_pattern = r"hpc_node-slurm-.\.hpc_name\.university_name\.edu"
         # The 'template' file contains the custom instructions to the HPC submission script, which
         # are stored in the 'templates' folder.
         template = "hpc_name.sh"

--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -56,7 +56,7 @@ The third line is the actual command that we want to add and the fourth line ens
 .. note::
 
     This custom HPC `class` (see code below) should be stored in its own `python` file (named `hpc_setup.py`) in the main directory and not in the the `project.py` file.
-    Storing it in the `project.py` file will result in the following warning, but the code should still execute properly.  
+    Storing it in the `project.py` file will result in the following warning, but the code should still execute properly.
 
     You will also need to `import hpc_setup` in the `project.py` file.
 

--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -55,9 +55,11 @@ The third line is the actual command that we want to add and the fourth line ens
 
 .. note::
 
-    This custom HPC `class` (see code below) should be stored in its own `python` file (named `hpc_setup.py`) in the main directory and not in the `project.py` file.
-    Storing it in the `project.py` file will result in the following warning, but the code should still execute properly.
-    You will also need to `import hpc_setup` in the `project.py` file.
+    The custom environment class should be defined in and then imported from a separate Python module file (e.g., `environments.py`) in the project root directory and not in the `project.py` file to avoid an inconsequential warning.
+    Defining it within in the `project.py` module will produce the warning shown below, but the code should still execute as expected.
+
+    "WARNING:flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'"
+    
 
 .. code-block:: python
 
@@ -71,9 +73,8 @@ The third line is the actual command that we want to add and the fourth line ens
         # are stored in the 'templates' folder.
         template = "hpc_name.sh"
 
-.. warning::
 
-    WARNING:flow.project:Unable to load template from package. Original Error '__main__.__spec__ is None'.
+    
 
 The base template
 =================

--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -55,7 +55,7 @@ The third line is the actual command that we want to add and the fourth line ens
 
 .. note::
 
-    This custom HPC `class` (see code below) should be stored in its own `python` file (named `hpc_setup.py`) in the main directory and not in the the `project.py` file.
+    This custom HPC `class` (see code below) should be stored in its own `python` file (named `hpc_setup.py`) in the main directory and not in the `project.py` file.
     Storing it in the `project.py` file will result in the following warning, but the code should still execute properly.
     You will also need to `import hpc_setup` in the `project.py` file.
 

--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -56,7 +56,9 @@ The third line is the actual command that we want to add and the fourth line ens
 .. note::
 
     This custom HPC `class` (see code below) should be stored in its own `python` file (named `hpc_setup.py`) in the main directory and not in the the `project.py` file.
-    Storing it in the `project.py` file will result in the following warning, but the code should still execute properly.
+    Storing it in the `project.py` file will result in the following warning, but the code should still execute properly.  
+
+    You will also need to `import hpc_setup` in the `project.py` file.
 
 .. code-block:: python
 


### PR DESCRIPTION
To avoid warnings when adding/using environments.

<!-- Provide a general summary of your changes in the Title above -->

## Description
Added some text in the documentation on how to add environments without getting warnings. 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [ x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-docs/blob/main/CONTRIBUTING.md).
- [x ] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-docs/blob/main/ContributorAgreement.md).
- [x ] My code follows the [code style guideline](https://github.com/glotzerlab/signac-docs/blob/main/CONTRIBUTING.md#code-style) of this project.
