### PR TITLE
Add explicit ReadTheDocs configuration.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,4 +10,5 @@ submodules:
     include: all
     recursive: true
 sphinx:
+  configuration: docs/source/conf.py
   fail_on_warning: true


### PR DESCRIPTION
## Description
ReadTheDocs shared the following announcement:

> We are announcing the deprecation of projects using Sphinx or MkDocs without an explicit configuration in their `.readthedocs.yaml` file. After January 20, 2025, Read the Docs will require explicit configuration for all Sphinx and MkDocs projects.

This adds the explicit key required by the above.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-docs/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-docs/blob/main/ContributorAgreement.md).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-docs/blob/main/CONTRIBUTING.md#code-style) of this project.
